### PR TITLE
Cast tensor to user specified type

### DIFF
--- a/python/raydp/spark/torch_sgd.py
+++ b/python/raydp/spark/torch_sgd.py
@@ -322,8 +322,7 @@ class _Dataset:
             self._label_type = torch.float
 
     def _get_next(self, index, feature_df, label_df):
-        # copy the scalar value
-        label = torch.tensor(label_df[index], dtype=self._label_type).view(1)
+        label = torch.as_tensor(label_df[index], dtype=self._label_type).view(1)
         current_feature = feature_df[index]
         if self._feature_shapes:
             feature_tensors = []


### PR DESCRIPTION
Cast `tensor` to user specified type, cast to `torch.float` by default for both features and label.