### PR TITLE
Fix bug in save_to_ray

### DIFF
--- a/python/raydp/spark/context.py
+++ b/python/raydp/spark/context.py
@@ -18,8 +18,6 @@ SUPPORTED_RESOURCE_MANAGER = ("ray", "standalone")
 
 class _spark_context(ContextDecorator):
     """
-    A class used to create the Spark cluster and get the Spark session.
-
     .. code-block:: python
 
         @_spark_context(app_name, num_executors, executor_cores, executor_memory):


### PR DESCRIPTION
In function save_to_ray in context.py, convert_to_spark returns a tuple instead of df. So we can't pass the returned value directly to the later function call.