### PR TITLE
Fix TaskContext leak and resource cleanup in                
   getRDDPartition

### DIFF
--- a/core/raydp-main/src/main/scala/org/apache/spark/executor/RayDPExecutor.scala
+++ b/core/raydp-main/src/main/scala/org/apache/spark/executor/RayDPExecutor.scala
@@ -324,29 +324,36 @@ class RayDPExecutor(
     val env = SparkEnv.get
     val context = SparkShimLoader.getSparkShims.getDummyTaskContext(partitionId, env)
     TaskContext.setTaskContext(context)
-    val schema = Schema.fromJSON(schemaStr)
-    val blockId = BlockId.apply("rdd_" + rddId + "_" + partitionId)
-    val iterator = env.blockManager.get(blockId)(classTag[Array[Byte]]) match {
-      case Some(blockResult) =>
-        blockResult.data.asInstanceOf[Iterator[Array[Byte]]]
-      case None =>
-        logWarning("The cached block has been lost. Cache it again via driver agent")
-        requestRecacheRDD(rddId, driverAgentUrl)
-        env.blockManager.get(blockId)(classTag[Array[Byte]]) match {
-          case Some(blockResult) =>
-            blockResult.data.asInstanceOf[Iterator[Array[Byte]]]
-          case None =>
-            throw new RayDPException("Still cannot get the block after recache!")
-        }
+    try {
+      val schema = Schema.fromJSON(schemaStr)
+      val blockId = BlockId.apply("rdd_" + rddId + "_" + partitionId)
+      val iterator = env.blockManager.get(blockId)(classTag[Array[Byte]]) match {
+        case Some(blockResult) =>
+          blockResult.data.asInstanceOf[Iterator[Array[Byte]]]
+        case None =>
+          logWarning("The cached block has been lost. Cache it again via driver agent")
+          requestRecacheRDD(rddId, driverAgentUrl)
+          env.blockManager.get(blockId)(classTag[Array[Byte]]) match {
+            case Some(blockResult) =>
+              blockResult.data.asInstanceOf[Iterator[Array[Byte]]]
+            case None =>
+              throw new RayDPException("Still cannot get the block after recache!")
+          }
+      }
+      val byteOut = new ByteArrayOutputStream()
+      val writeChannel = new WriteChannel(Channels.newChannel(byteOut))
+      try {
+        MessageSerializer.serialize(writeChannel, schema)
+        iterator.foreach(writeChannel.write)
+        ArrowStreamWriter.writeEndOfStream(writeChannel, new IpcOption)
+        byteOut.toByteArray
+      } finally {
+        writeChannel.close()
+        byteOut.close()
+      }
+    } finally {
+      env.blockManager.releaseAllLocksForTask(context.taskAttemptId())
+      TaskContext.unset()
     }
-    val byteOut = new ByteArrayOutputStream()
-    val writeChannel = new WriteChannel(Channels.newChannel(byteOut))
-    MessageSerializer.serialize(writeChannel, schema)
-    iterator.foreach(writeChannel.write)
-    ArrowStreamWriter.writeEndOfStream(writeChannel, new IpcOption)
-    val result = byteOut.toByteArray
-    writeChannel.close
-    byteOut.close
-    result
   }
 }


### PR DESCRIPTION
## Summary                                                                                                                                            
   -  sets a dummy  but never unsets it. Since executor actors reuse threads (), a stale  leaks into subsequent      
   operations on the same thread, which can cause subtle issues with metrics, accumulators, and task-local state.
   - If an exception occurs mid-method, neither the / nor the  read locks are cleaned up.
   - Wraps the method body in  to guarantee:
     -  read locks are released via 
     -  is unset via 
     -  and  are closed

   ## Test plan
   - [x] Verify core compiles cleanly against all shim targets (3.2.2, 3.3.0, 3.4.0, 3.5.0)
   - [ ] Run  round-trip conversion
   - [ ] Confirm no resource leak warnings in executor logs after repeated conversions.