### PR TITLE
Fix RayDPDriverAgent Rpc bind

### DIFF
--- a/core/raydp-main/src/main/scala/org/apache/spark/deploy/raydp/RayDPDriverAgent.scala
+++ b/core/raydp-main/src/main/scala/org/apache/spark/deploy/raydp/RayDPDriverAgent.scala
@@ -17,8 +17,6 @@
 
 package org.apache.spark.deploy.raydp
 
-import io.ray.runtime.config.RayConfig
-
 import org.apache.spark.{SecurityManager, SparkConf, SparkContext}
 import org.apache.spark.internal.Logging
 import org.apache.spark.rpc._
@@ -34,7 +32,11 @@ class RayDPDriverAgent() {
 
   def init(): Unit = {
     val securityMgr = new SecurityManager(conf)
-    val host = RayConfig.create().nodeIp
+    val host = spark.conf.getOption("spark.driver.bindAddress")
+      .orElse(spark.conf.getOption("spark.driver.host"))
+      .getOrElse(throw new RuntimeException(
+        "spark.driver.bindAddress or spark.driver.host must be set " +
+        "for RayDPDriverAgent to bind its RPC endpoint"))
     rpcEnv = RpcEnv.create(
       RayAppMaster.ENV_NAME,
       host,
@@ -42,7 +44,6 @@ class RayDPDriverAgent() {
       0,
       conf,
       securityMgr,
-      // limit to single-thread
       numUsableCores = 1,
       clientMode = false)
     // register endpoint

--- a/python/raydp/spark/ray_cluster.py
+++ b/python/raydp/spark/ray_cluster.py
@@ -18,7 +18,6 @@
 import glob
 import os
 import sys
-import platform
 import pyspark
 from typing import Any, Dict
 
@@ -119,11 +118,10 @@ class SparkCluster(Cluster):
         self._configs["spark.executor.instances"] = str(self._num_executors)
         self._configs["spark.executor.cores"] = str(self._executor_cores)
         self._configs["spark.executor.memory"] = str(self._executor_memory)
-        if platform.system() != "Darwin":
-            driver_node_ip = ray.util.get_node_ip_address()
-            if "spark.driver.host" not in self._configs:
-                self._configs["spark.driver.host"] = str(driver_node_ip)
-                self._configs["spark.driver.bindAddress"] = str(driver_node_ip)
+        driver_node_ip = ray.util.get_node_ip_address()
+        if "spark.driver.host" not in self._configs:
+            self._configs["spark.driver.host"] = str(driver_node_ip)
+            self._configs["spark.driver.bindAddress"] = str(driver_node_ip)
 
         raydp_cp = os.path.abspath(os.path.join(os.path.abspath(__file__), "../../jars/*"))
         ray_cp = os.path.abspath(os.path.join(os.path.dirname(ray.__file__), "jars/*"))


### PR DESCRIPTION
When `fault_tolerant_mode=True` (the default), `connect_spark_driver_to_ray()` calls `RayAppMaster.setProperties(jvm_properties)` which loads the **master actor's** Ray config into the driver JVM. This sets `ray.node-ip` to the master's IP. Then `ObjectStoreWriter.connectToRay()` creates a `RayDPDriverAgent`, which calls `RayConfig.create().nodeIp` to get the bind address -- but this now returns the **master's** IP, not the driver's local IP.

The call chain:

```
init_spark(fault_tolerant_mode=True)
  -> connect_spark_driver_to_ray()
    -> RayAppMaster.setProperties(master_ray_configs)    // sets ray.node-ip = master's IP
    -> ObjectStoreWriter.connectToRay()
      -> new RayDPDriverAgent()
        -> RayConfig.create().nodeIp                      // returns master's IP (WRONG)
        -> RpcEnv.create(..., host=masterIp, ...)         // BindException!
```