### PR TITLE
fix(shuffle): make shuffle service actors idempotent and enable fault tolerance

### DIFF
--- a/core/raydp-main/src/main/java/org/apache/spark/deploy/raydp/ExternalShuffleServiceUtils.java
+++ b/core/raydp-main/src/main/java/org/apache/spark/deploy/raydp/ExternalShuffleServiceUtils.java
@@ -18,21 +18,32 @@
 package org.apache.spark.deploy.raydp;
 
 import java.util.List;
+import java.util.Optional;
 
 import io.ray.api.ActorHandle;
 import io.ray.api.Ray;
 
 public class ExternalShuffleServiceUtils {
-  public static ActorHandle<RayExternalShuffleService> createShuffleService(
-      String node, List<String> options) {
-    return Ray.actor(RayExternalShuffleService::new)
-              .setResource("node:" + node, 0.01)
-              .setJvmOptions(options).remote();
+
+  private static String getShuffleServiceActorName(String node) {
+    return "raydp-shuffle-service-" + node.replace('.', '-');
   }
 
-  public static void startShuffleService(
-      ActorHandle<RayExternalShuffleService> handle) {
-    handle.task(RayExternalShuffleService::start).remote();
+  public static ActorHandle<RayExternalShuffleService> createShuffleService(
+      String node, List<String> options) {
+    String actorName = getShuffleServiceActorName(node);
+    Optional<ActorHandle<RayExternalShuffleService>> existing = Ray.getActor(actorName);
+    if (existing.isPresent()) {
+      return existing.get();
+    }
+
+    return Ray.actor(RayExternalShuffleService::new)
+              .setName(actorName)
+              .setResource("node:" + node, 0.01)
+              .setJvmOptions(options)
+              .setMaxRestarts(-1)
+              .setMaxTaskRetries(-1)
+              .remote();
   }
 
   public static void stopShuffleService(

--- a/core/raydp-main/src/main/scala/org/apache/spark/deploy/raydp/RayAppMaster.scala
+++ b/core/raydp-main/src/main/scala/org/apache/spark/deploy/raydp/RayAppMaster.scala
@@ -151,16 +151,12 @@ class RayAppMaster(host: String,
       case RegisterExecutor(executorId, executorIp) =>
         val success = appInfo.registerExecutor(executorId)
         if (success) {
-          // external shuffle service is enabled
-          if (conf.getBoolean("spark.shuffle.service.enabled", false)) {
-            // the node executor is in has not started shuffle service
-            if (!nodesWithShuffleService.contains(executorIp)) {
-              logInfo(s"Starting shuffle service on ${executorIp}")
-              val service = ExternalShuffleServiceUtils.createShuffleService(
-                executorIp, shuffleServiceOptions.toBuffer.asJava)
-              ExternalShuffleServiceUtils.startShuffleService(service)
-              nodesWithShuffleService(executorIp) = service
-            }
+          if (conf.getBoolean("spark.shuffle.service.enabled", false) &&
+              !nodesWithShuffleService.contains(executorIp)) {
+            logInfo(s"Starting shuffle service on ${executorIp}")
+            val service = ExternalShuffleServiceUtils.createShuffleService(
+              executorIp, shuffleServiceOptions.toBuffer.asJava)
+            nodesWithShuffleService(executorIp) = service
           }
           setUpExecutor(executorId)
         }

--- a/core/raydp-main/src/main/scala/org/apache/spark/deploy/raydp/RayAppMaster.scala
+++ b/core/raydp-main/src/main/scala/org/apache/spark/deploy/raydp/RayAppMaster.scala
@@ -153,7 +153,7 @@ class RayAppMaster(host: String,
         if (success) {
           if (conf.getBoolean("spark.shuffle.service.enabled", false) &&
               !nodesWithShuffleService.contains(executorIp)) {
-            logInfo(s"Starting shuffle service on ${executorIp}")
+            logInfo(s"Ensuring shuffle service on ${executorIp}")
             val service = ExternalShuffleServiceUtils.createShuffleService(
               executorIp, shuffleServiceOptions.toBuffer.asJava)
             nodesWithShuffleService(executorIp) = service

--- a/core/raydp-main/src/main/scala/org/apache/spark/deploy/raydp/RayExternalShuffleService.scala
+++ b/core/raydp-main/src/main/scala/org/apache/spark/deploy/raydp/RayExternalShuffleService.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.deploy.raydp
 
-import io.ray.api.Ray;
+import io.ray.api.Ray
 
 import org.apache.spark.{SecurityManager, SparkConf}
 import org.apache.spark.deploy.ExternalShuffleService
@@ -27,6 +27,8 @@ class RayExternalShuffleService() extends Logging {
   val conf = new SparkConf()
   val mgr = new SecurityManager(conf)
   val instance = new ExternalShuffleService(conf, mgr)
+
+  start()
 
   def start(): Unit = {
       instance.start()

--- a/core/raydp-main/src/main/scala/org/apache/spark/deploy/raydp/RayExternalShuffleService.scala
+++ b/core/raydp-main/src/main/scala/org/apache/spark/deploy/raydp/RayExternalShuffleService.scala
@@ -30,7 +30,7 @@ class RayExternalShuffleService() extends Logging {
 
   start()
 
-  def start(): Unit = {
+  final def start(): Unit = {
       instance.start()
   }
 


### PR DESCRIPTION
## Motivation
Prevent duplicate shuffle service actors on the same node by assigning unique names and reusing existing actors. Also enable fault tolerance with max restarts and task retries, and remove the now-unnecessary explicit start call.
## Approach

- Introduce a named actor pattern in `ExternalShuffleServiceUtils.createShuffleService()`: generate a unique name `raydp-shuffle-service-<ip>` based on the node IP
- Call Ray.getActor(actorName) first — if an actor already exists, return the existing handle instead of creating a new one
- Set `setMaxRestarts(-1) / setMaxTaskRetries(-1)` to enable automatic fault recovery at the Ray level
- Remove the separate `startShuffleService()` method; instead, call `start()` inside the `RayExternalShuffleService` constructor so the service auto-starts on creation
- Simplify the shuffle service creation logic in RayAppMaster when an executor registers, removing the redundant explicit start call
