### PR TITLE
fix(sparksubmit): stop SparkContext when running on Ray master

### DIFF
--- a/core/raydp-main/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/raydp-main/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -957,8 +957,9 @@ private[spark] class SparkSubmit extends Logging {
       case t: Throwable =>
         throw findCause(t)
     } finally {
-      if (args.master.startsWith("k8s") && !isShell(args.primaryResource) &&
-          !isSqlShell(args.mainClass) && !isThriftServer(args.mainClass)) {
+      if ((args.master.startsWith("k8s") || args.master.startsWith("ray")) &&
+          !isShell(args.primaryResource) && !isSqlShell(args.mainClass) &&
+          !isThriftServer(args.mainClass)) {
         try {
           SparkContext.getActive.foreach(_.stop())
         } catch {


### PR DESCRIPTION
## What does this PR do?

Support stop SparkContext after application finish.

## Why is this change needed?

Add `ray` to the master check in `SparkSubmit`'s finally block to ensure SparkContext is properly stopped on application exit, matching the existing cleanup behavior for the `k8s` master.

## Related Issue

Fixes #

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring
- [ ] Build / CI / dependency change
- [ ] Other

## How was this tested?

I have test it manually. Previously, PySpark applications would hang and not terminate if the code did not explicitly invoke SparkContext.stop(). This behavior has been fixed in this pr.

## Checklist

- [ ] I have added or updated tests if needed
- [ ] I have updated documentation if needed
- [x] I have run relevant tests locally
- [ ] I have checked that this change is backward compatible
