### PR TITLE
feat(executor): accmulate memoryoverhead for ray actor.

### DIFF
--- a/core/raydp-main/src/main/scala/org/apache/spark/deploy/raydp/ApplicationDescription.scala
+++ b/core/raydp-main/src/main/scala/org/apache/spark/deploy/raydp/ApplicationDescription.scala
@@ -39,13 +39,15 @@ private[spark] case class ApplicationDescription(
     rayActorCPU: Double,
     command: Command,
     user: String = System.getProperty("user.name", "<unknown>"),
-    resourceReqsPerExecutor: Map[String, Double] = Map.empty) {
+    resourceReqsPerExecutor: Map[String, Double] = Map.empty,
+    rayActorMemoryPerExecutorMB: Int) {
 
   def withNewCommand(newCommand: Command): ApplicationDescription = {
     ApplicationDescription(name = name,
       numExecutors = numExecutors, coresPerExecutor = coresPerExecutor,
       memoryPerExecutorMB = memoryPerExecutorMB, command = newCommand, user = user,
       resourceReqsPerExecutor = resourceReqsPerExecutor,
-      rayActorCPU = rayActorCPU)
+      rayActorCPU = rayActorCPU,
+      rayActorMemoryPerExecutorMB = rayActorMemoryPerExecutorMB)
   }
 }

--- a/core/raydp-main/src/main/scala/org/apache/spark/deploy/raydp/RayAppMaster.scala
+++ b/core/raydp-main/src/main/scala/org/apache/spark/deploy/raydp/RayAppMaster.scala
@@ -262,10 +262,11 @@ class RayAppMaster(host: String,
       val rayActorCPU = this.appInfo.desc.rayActorCPU
       val memory = appInfo.desc.memoryPerExecutorMB
       val executorId = s"${appInfo.getNextExecutorId()}"
+      val rayActorMemory = appInfo.desc.rayActorMemoryPerExecutorMB
 
       logInfo(
         s"Requesting Spark executor with Ray logical resource " +
-          s"{ CPU: $rayActorCPU, " +
+          s"{ CPU: $rayActorCPU,  memory: ${rayActorMemory}MB," +
           s"${appInfo.desc.resourceReqsPerExecutor
             .map { case (name, amount) => s"$name: $amount" }.mkString(", ")} }..")
       // TODO: Support generic fractional logical resources using prefix spark.ray.actor.resource.*
@@ -291,7 +292,7 @@ class RayAppMaster(host: String,
         executorId,
         getAppMasterEndpointUrl(),
         rayActorCPU,
-        memory,
+        rayActorMemory,
         // This won't work, Spark expect integer in custom resources,
         // please see python test test_spark_on_fractional_custom_resource
         appInfo.desc.resourceReqsPerExecutor

--- a/core/raydp-main/src/main/scala/org/apache/spark/scheduler/cluster/raydp/RayCoarseGrainedSchedulerBackend.scala
+++ b/core/raydp-main/src/main/scala/org/apache/spark/scheduler/cluster/raydp/RayCoarseGrainedSchedulerBackend.scala
@@ -155,9 +155,12 @@ class RayCoarseGrainedSchedulerBackend(
 
     // Start executors with a few necessary configs for registering with the scheduler
     val sparkJavaOpts = Utils.sparkJavaOpts(conf, SparkConf.isExecutorStartupConf)
-    // add Xmx, it should not be set in java opts, because Spark is not allowed.
-    // We also add Xms to ensure the Xmx >= Xms
-    val memoryLimit = Seq(s"-Xms${sc.executorMemory}M", s"-Xmx${sc.executorMemory}M")
+    val executorHeapMemoryMb = sc.executorMemory
+    val executorOverheadMb = getExecutorMemoryOverheadMb(executorHeapMemoryMb)
+    val rayActorMemoryMb = executorHeapMemoryMb + executorOverheadMb
+
+    // Keep executor heap as spark.executor.memory; overhead is for process-level reservation.
+    val memoryLimit = Seq(s"-Xms${executorHeapMemoryMb}M", s"-Xmx${executorHeapMemoryMb}M")
 
     val javaOpts = sparkJavaOpts ++ extraJavaOpts ++ memoryLimit ++ javaAgentOpt()
 
@@ -182,7 +185,11 @@ class RayCoarseGrainedSchedulerBackend(
       coresPerExecutor = coresPerExecutor, memoryPerExecutorMB = sc.executorMemory,
       command = command,
       resourceReqsPerExecutor = resourcesInMap,
-      rayActorCPU = rayActorCPU)
+      rayActorCPU = rayActorCPU,
+      rayActorMemoryPerExecutorMB = rayActorMemoryMb)
+
+    logInfo(s"Executor memory profile: heap=${executorHeapMemoryMb}MB, " +
+      s"overhead=${executorOverheadMb}MB, rayActorReserve=${rayActorMemoryMb}MB")
 
     val rpcEnv = sc.env.rpcEnv
     appMasterRef.set(rpcEnv.setupEndpoint(
@@ -225,6 +232,20 @@ class RayCoarseGrainedSchedulerBackend(
       }
     }
     results
+  }
+
+  private def getExecutorMemoryOverheadMb(executorMemoryMb: Int): Int = {
+    // This factor is the fraction of executor memory reserved for non-heap overhead
+    // (for example JVM/native memory and container overhead). Default to 10% when
+    // the config is not set to match Spark's standard executor overhead sizing.
+    val overheadFactor = sc.conf.getOption("spark.executor.memoryOverheadFactor")
+      .map(_.toDouble)
+      .getOrElse(0.10d)
+
+    ResourceProfile.calculateOverHeadMemory(
+      sc.conf.get(config.EXECUTOR_MEMORY_OVERHEAD),
+      executorMemoryMb,
+      overheadFactor).toInt
   }
 
   private def javaAgentOpt(): Seq[String] = {


### PR DESCRIPTION
## Motivation
Ray executor actor memory is set to only spark.executor.memory (JVM heap), without reserving memory for off-heap usage (native memory, metaspace, etc.). This causes the executor process to be killed by Ray's OOM killer when actor exceeds the declared actor memory.
## Approach
Approach

- In RayCoarseGrainedSchedulerBackend, compute `rayActorMemoryMb = executorHeapMemoryMb + executorOverheadMb`
   - `executorOverheadMb` is calculated by `getExecutorMemoryOverheadMb(),` reusing Spark's standard `ResourceProfile.calculateOverHeadMemory()`
   - Supports both `spark.executor.memoryOverhead` (absolute) and `spark.executor.memoryOverheadFactor` (default 10%)
- `Xms / -Xmx` still use `executorHeapMemoryMb` (heap size unchanged); `rayActorMemoryMb` is only used for the Ray actor memory resource declaration
- Add `rayActorMemoryPerExecutorMB` field to `ApplicationDescription`, propagating the value to `RayAppMaster`
- `RayAppMaster.requestExecutor()` uses `rayActorMemoryPerExecutorMB` instead of the original `memoryPerExecutorMB` as the actor memory