### PR TITLE
fix(executor): switch process working dir via native chdir

### DIFF
--- a/core/raydp-main/pom.xml
+++ b/core/raydp-main/pom.xml
@@ -132,6 +132,12 @@
     </dependency>
 
     <dependency>
+      <groupId>net.java.dev.jna</groupId>
+      <artifactId>jna</artifactId>
+      <version>5.13.0</version>
+    </dependency>
+
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
       <version>${jackson.version}</version>

--- a/core/raydp-main/src/main/scala/org/apache/spark/executor/RayDPExecutor.scala
+++ b/core/raydp-main/src/main/scala/org/apache/spark/executor/RayDPExecutor.scala
@@ -25,8 +25,8 @@ import java.util.concurrent.atomic.AtomicBoolean
 
 import scala.reflect.classTag
 
-import com.sun.jna.{Library, Native}
 import com.intel.raydp.shims.SparkShimLoader
+import com.sun.jna.{Library, Native}
 import io.ray.api.Ray
 import io.ray.runtime.config.RayConfig
 import org.apache.arrow.vector.ipc.{ArrowStreamWriter, WriteChannel}

--- a/core/raydp-main/src/main/scala/org/apache/spark/executor/RayDPExecutor.scala
+++ b/core/raydp-main/src/main/scala/org/apache/spark/executor/RayDPExecutor.scala
@@ -19,11 +19,13 @@ package org.apache.spark.executor
 
 import java.io.{ByteArrayOutputStream, File}
 import java.nio.channels.Channels
+import java.nio.file.Files
 import java.nio.file.Paths
 import java.util.concurrent.atomic.AtomicBoolean
 
 import scala.reflect.classTag
 
+import com.sun.jna.{Library, Native}
 import com.intel.raydp.shims.SparkShimLoader
 import io.ray.api.Ray
 import io.ray.runtime.config.RayConfig
@@ -110,6 +112,7 @@ class RayDPExecutor(
     }
     createWorkingDir(appId)
     setUserDir()
+    switchProcessWorkingDirBestEffort()
 
     val userClassPath = classPathEntries.split(java.io.File.pathSeparator)
       .filter(_.nonEmpty).map(new File(_).toURI.toURL)
@@ -188,6 +191,48 @@ class RayDPExecutor(
     logInfo(s"Set user.dir to ${workingDir.getAbsolutePath}")
   }
 
+  private def switchProcessWorkingDirBestEffort(): Unit = {
+    val targetDir = workingDir.getAbsolutePath
+    val beforeCwd = getProcessWorkingDir
+
+    try {
+      val rc = LibCHolder.libc.chdir(targetDir)
+      if (rc != 0) {
+        logWarning(s"Failed to switch executor process cwd from ${beforeCwd} to ${targetDir}, " +
+          s"chdir returned rc=${rc}, errno=${Native.getLastError}")
+        return
+      }
+
+      val afterCwd = getProcessWorkingDir
+      logInfo(s"Switched executor process cwd from ${beforeCwd} to ${afterCwd}, " +
+        s"target is ${targetDir}")
+    } catch {
+      case e: Throwable =>
+        logWarning(s"Failed to switch executor process cwd from ${beforeCwd} to ${targetDir}", e)
+    }
+  }
+
+  private def getProcessWorkingDir: String = {
+    try {
+      val procCwd = Paths.get("/proc/self/cwd")
+      if (Files.exists(procCwd)) {
+        Files.readSymbolicLink(procCwd).toString
+      } else {
+        new File(".").getCanonicalPath
+      }
+    } catch {
+      case _: Throwable => "<unknown>"
+    }
+  }
+
+  private trait LibC extends Library {
+    def chdir(path: String): Int
+  }
+
+  private object LibCHolder {
+    lazy val libc: LibC = Native.load("c", classOf[LibC]).asInstanceOf[LibC]
+  }
+
   private def serveAsExecutor(
       appId: String,
       driverUrl: String,
@@ -238,7 +283,10 @@ class RayDPExecutor(
       val workerTmpDir = new File(workingDir, "_tmp")
       workerTmpDir.mkdir()
       assert(workerTmpDir.exists() && workerTmpDir.isDirectory)
-      SparkEnv.get.driverTmpDir = Some(workerTmpDir.getAbsolutePath)
+      // Keep Spark's distributed file/archive root aligned with executor workingDir.
+      SparkEnv.get.driverTmpDir = Some(workingDir.getAbsolutePath)
+      logInfo(s"Set SparkEnv.driverTmpDir to ${workingDir.getAbsolutePath}, " +
+        s"executor tmp dir is ${workerTmpDir.getAbsolutePath}")
 
       val appMasterRef = env.rpcEnv.setupEndpointRefByURI(appMasterURL)
       appMasterRef.ask(ExecutorStarted(executorId))


### PR DESCRIPTION
## Motivation
The RayDP executor process CWD remains the container default directory (e.g., / or /opt) rather than the executor's workingDir. This causes Spark distributed files (--files) and archives (--archives) to be extracted to the wrong location, making it impossible for executor code to find them at the expected paths.
## Approach
- JNA native `chdir` call: Add JNA dependency to `pom.xml`, define a `LibC` interface to load the `chdir()` syscall from libc. After `setUserDir()` (which only changes the user.dir system property), add `switchProcessWorkingDirBestEffort()` to actually switch the process-level CWD
- Align `SparkEnv.driverTmpDir`: Change `driverTmpDir` from `workingDir/_tmp` to `workingDir` itself, so the root directory for Spark distributed files matches the executor's `workingDir`, and files/archives are extracted to the correct path
- Fault tolerance: `chdir` failure only logs a warning and does not interrupt executor startup; reads `cwd` before and after the switch for diagnostic logging