### PR TITLE
[RAYDP #476] Use semantic version comparison for Spark log4j configuration selection.

### DIFF
--- a/python/raydp/tests/test_versions.py
+++ b/python/raydp/tests/test_versions.py
@@ -1,0 +1,39 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import pytest
+
+from raydp import versions
+
+
+@pytest.mark.parametrize(
+    "spark_version",
+    ["3.3.0", "3.5.7", "3.5.0.dev0", "3.10.0", "4.0.0"])
+def test_spark_versions_3_3_and_newer_use_log4j2(spark_version):
+    assert versions._uses_log4j2(spark_version)
+
+
+@pytest.mark.parametrize(
+    "spark_version",
+    ["2.4.8", "3.1.3", "3.2.0", "3.2.2", "3.3.0rc1"])
+def test_spark_versions_older_than_3_3_use_log4j1(spark_version):
+    assert not versions._uses_log4j2(spark_version)
+
+
+def test_invalid_spark_version_raises_value_error():
+    with pytest.raises(ValueError, match="Invalid Spark version"):
+        versions._uses_log4j2("not-a-version")

--- a/python/raydp/versions.py
+++ b/python/raydp/versions.py
@@ -15,16 +15,23 @@
 # limitations under the License.
 #
 
-import re
+from packaging.version import InvalidVersion, Version
+
 import pyspark
+
+
+def _uses_log4j2(spark_version: str) -> bool:
+    try:
+        return Version(spark_version) >= Version("3.3")
+    except InvalidVersion as exc:
+        raise ValueError(f"Invalid Spark version: {spark_version}") from exc
 
 
 # log4j1 if spark version <= 3.2, otherwise, log4j2
 SPARK_LOG4J_VERSION = "log4j"
 SPARK_LOG4J_CONFIG_FILE_NAME_KEY = "log4j.configurationFile"
 SPARK_LOG4J_CONFIG_FILE_NAME_DEFAULT = "log4j-default.properties"
-_spark_ver = re.search("\\d+\\.\\d+", pyspark.version.__version__)
-if _spark_ver.group(0) > "3.2":
+if _uses_log4j2(pyspark.version.__version__):
     SPARK_LOG4J_VERSION = "log4j2"
     SPARK_LOG4J_CONFIG_FILE_NAME_KEY = "log4j2.configurationFile"
     SPARK_LOG4J_CONFIG_FILE_NAME_DEFAULT = "log4j2-default.properties"

--- a/python/setup.py
+++ b/python/setup.py
@@ -96,6 +96,7 @@ try:
 
     install_requires = [
         "numpy",
+        "packaging",
         "pandas >= 1.1.4",
         "psutil",
         "pyarrow >= 4.0.1",


### PR DESCRIPTION
## What does this PR do?

This PR updates the Spark log4j configuration selection logic to use semantic version comparison instead of string comparison.

Specifically, it updates `python/raydp/versions.py` to compare Spark versions with `packaging.version.Version`, and adds unit tests for the expected log4j selection behavior.

## Why is this change needed?

RayDP currently compares Spark versions as strings when deciding whether to use log4j1 or log4j2:

```python
_spark_ver = re.search("\\d+\\.\\d+", pyspark.version.__version__)
if _spark_ver.group(0) > "3.2":
```

Although this works for the currently tested Spark versions, comparing version numbers as plain strings is fragile and can produce incorrect results for some version formats.

Using semantic version comparison makes the logic clearer, safer, and easier to maintain as Spark version support evolves.

## Related Issue
Fixes #476 

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Documentation update
- [X] Test update
- [ ] Refactoring
- [ ] Build / CI / dependency change
- [ ] Other

## How was this tested?

Ran the related unit tests locally.

Result:
```
14 passed, 41 warnings in 17.08s
```

## Checklist

- [x] I have added or updated tests if needed
- [ ] I have updated documentation if needed
- [x] I have run relevant tests locally
- [x] I have checked that this change is backward compatible
