### PR TITLE
[RAYDP #478] Add a GitHub Pull Request template.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,38 @@
+## What does this PR do?
+
+Briefly describe the purpose of this PR.
+
+## Why is this change needed?
+
+Explain the background, issue, or motivation for this change.
+
+## Related Issue
+
+Fixes #
+
+## Type of Change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Documentation update
+- [ ] Test update
+- [ ] Refactoring
+- [ ] Build / CI / dependency change
+- [ ] Other
+
+## How was this tested?
+
+Describe the tests you ran.
+
+Example:
+
+```bash
+pytest python/raydp/tests/ -v
+```
+
+## Checklist
+
+- [ ] I have added or updated tests if needed
+- [ ] I have updated documentation if needed
+- [ ] I have run relevant tests locally
+- [ ] I have checked that this change is backward compatible


### PR DESCRIPTION
## What does this PR do?

This PR adds a GitHub Pull Request template for RayDP.

The new template is added at:

```text
.github/pull_request_template.md
```

It provides standard sections for contributors to describe the purpose, motivation, related issue, change type, testing steps, and checklist items for each PR.

## Why is this change needed?

RayDP currently does not have a Pull Request template, so new PR descriptions are empty by default.

This makes it harder for maintainers and reviewers to quickly understand:

- what the PR changes
- why the change is needed
- which issue it relates to
- how the change was tested
- whether tests or documentation were updated

Adding a PR template helps standardize contribution information and improves the review workflow.

## Related Issue
Fixes #478 

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Test update
- [ ] Refactoring
- [ ] Build / CI / dependency change
- [ ] Other

## How was this tested?

This change only adds a GitHub PR template and does not affect runtime behavior.

## Checklist

- [ ] I have added or updated tests if needed
- [x] I have updated documentation if needed
- [x] I have run relevant tests locally
- [x] I have checked that this change is backward compatible