### PR TITLE
[RAYDP #482] Update setup-python action and relax Python 3.10 patch version in CI workflows.

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -35,9 +35,9 @@ jobs:
     steps:
     - uses: actions/checkout@61b9e3751b92087fd0b06925ba6dd6314e06f089 # master
     - name: Set up Python 3.10
-      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
       with:
-        python-version: 3.10.14
+        python-version: "3.10"
     - name: Set up JDK 1.8
       uses: actions/setup-java@b6e674f4b717d7b0ae3baee0fbe79f498905dfde # v1.4.4
       with:

--- a/.github/workflows/pypi_release.yml
+++ b/.github/workflows/pypi_release.yml
@@ -43,9 +43,9 @@ jobs:
         ref: ${{ inputs.tag }}
         fetch-depth: 0
     - name: Set up Python 3.10
-      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
       with:
-        python-version: 3.10.14
+        python-version: "3.10"
     - name: Set up JDK 1.8
       uses: actions/setup-java@b6e674f4b717d7b0ae3baee0fbe79f498905dfde # v1.4.4
       with:
@@ -57,7 +57,7 @@ jobs:
       uses: actions/cache@8492260343ad570701412c2f464a5877dc76bace # v2
       with:
         path: ~/.cache/pip
-        key: ubuntu-latest-3.10.14-pip
+        key: ubuntu-latest-3.10-pip
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/ray_nightly_test.yml
+++ b/.github/workflows/ray_nightly_test.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        python-version: [3.9, 3.10.14]
+        python-version: ["3.9", "3.10"]
         spark-version: [3.3.2, 3.4.0, 3.5.0]
 
     runs-on: ${{ matrix.os }}
@@ -39,7 +39,7 @@ jobs:
     steps:
       - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Set up JDK 17
@@ -86,7 +86,7 @@ jobs:
             3.9)
               pip install "ray[train,default] @ https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp39-cp39-manylinux2014_x86_64.whl"
               ;;
-            3.10.14)
+            3.10)
               pip install "ray[train,default] @ https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp310-cp310-manylinux2014_x86_64.whl"
               ;;
           esac

--- a/.github/workflows/raydp.yml
+++ b/.github/workflows/raydp.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.9, 3.10.14]
+        python-version: ["3.9", "3.10"]
         spark-version: [3.3.2, 3.4.0, 3.5.0]
         ray-version: [2.37.0, 2.40.0, 2.50.0]
 
@@ -41,7 +41,7 @@ jobs:
     steps:
       - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Set up JDK 17


### PR DESCRIPTION
## What does this PR do?

This PR updates the Python setup step in RayDP CI workflows.

Specifically, it:

- updates `actions/setup-python` from the old pinned v2.3.4 commit to a pinned v5 commit
- relaxes Python `3.10.14` to `"3.10"` in CI workflows

Affected workflows:

```text
.github/workflows/raydp.yml
.github/workflows/ray_nightly_test.yml
.github/workflows/pypi.yml
.github/workflows/pypi_release.yml
```

## Why is this change needed?

CI can fail during the Python setup step before RayDP code is executed:

```
Version 3.10.14 was not found in the local cache
Error: Bad credentials
```

This happens when the runner does not have the exact Python patch version `3.10.14` in its local tool cache and `actions/setup-python` fails while trying to download it.

Using a newer actions/setup-python version and relaxing the Python version to "3.10" should reduce CI failures caused by missing exact patch versions.

## Related Issue

Fixes #482.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring
- [x] Build / CI / dependency change
- [ ] Other

## How was this tested?

Describe the tests you ran.

Example:

```bash
pytest python/raydp/tests/ -v
```

## Checklist

- [ ] I have added or updated tests if needed
- [ ] I have updated documentation if needed
- [x] I have run relevant tests locally
- [x] I have checked that this change is backward compatible
