### PR TITLE
[RAYDP #484] Add GitHub issue templates for bug reports and feature requests.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,57 @@
+---
+name: Bug report
+description: Report a reproducible problem in RayDP
+title: "[Bug] "
+labels: ["bug"]
+assignees: []
+---
+
+## What happened?
+
+Describe the problem clearly and concisely.
+
+## How to reproduce
+
+Steps to reproduce the behavior:
+
+1.
+2.
+3.
+
+If possible, include a minimal code snippet or script.
+
+```python
+# Minimal reproduction
+```
+
+## Expected behavior
+
+Describe what you expected to happen.
+
+## Actual behavior
+
+Describe what actually happened.
+
+## Environment
+
+Please provide the relevant environment information:
+
+- RayDP version:
+- Ray version:
+- PySpark / Spark version:
+- Python version:
+- Java version:
+- OS / platform:
+- Deployment mode: local / cluster / Kubernetes / other
+
+## Logs and error messages
+
+Paste relevant logs, stack traces, or error messages here.
+
+```text
+
+```
+
+## Additional context
+
+Add any other context that may help diagnose the issue.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: RayDP documentation
+    url: https://github.com/ray-project/raydp#readme
+    about: Please check the README and docs before opening an issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,27 @@
+---
+name: Feature request
+description: Suggest an idea or improvement for RayDP
+title: "[Feature] "
+labels: ["enhancement"]
+assignees: []
+---
+
+## What would you like to see?
+
+Describe the feature or improvement you would like RayDP to support.
+
+## Why is this needed?
+
+Explain the use case, motivation, or problem this feature would solve.
+
+## Proposed solution
+
+Describe the solution you have in mind, if any.
+
+## Alternatives considered
+
+Describe any alternative approaches or workarounds you have considered.
+
+## Additional context
+
+Add any other context, examples, links, or screenshots that may help explain the request.


### PR DESCRIPTION
## What does this PR do?

This PR adds GitHub issue templates for RayDP.

It adds the following files:

```text
.github/ISSUE_TEMPLATE/bug_report.md
.github/ISSUE_TEMPLATE/feature_request.md
.github/ISSUE_TEMPLATE/config.yml
```

The templates provide structured sections for bug reports and feature requests, including reproduction steps, environment information, logs, motivation, proposed solutions, and additional context.

## Why is this change needed?

RayDP currently does not provide GitHub issue templates, so new issues start from a blank description by default.

This can make issue triage harder because important information may be missing, such as:

- steps to reproduce a bug
- expected and actual behavior
- RayDP / Ray / Spark / Python / Java version information
- deployment environment
- logs or error messages
- motivation and proposed solution for feature requests

Adding issue templates helps users provide more complete information and makes issue triage easier for maintainers.

## Related Issue

Fixes #484 

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Test update
- [ ] Refactoring
- [ ] Build / CI / dependency change
- [ ] Other

## How was this tested?

Describe the tests you ran.

Example:

```bash
pytest python/raydp/tests/ -v
```

## Checklist

- [ ] I have added or updated tests if needed
- [x] I have updated documentation if needed
- [x] I have run relevant tests locally
- [x] I have checked that this change is backward compatible
