### PR TITLE
fix(RayAppMaster): refactor executor state in RayAppMaster.

### DIFF
--- a/.github/workflows/raydp.yml
+++ b/.github/workflows/raydp.yml
@@ -82,7 +82,9 @@ jobs:
           else
             pip install torch
           fi
-          pip install pyarrow "ray[train,default]==${{ matrix.ray-version }}" tqdm pytest tabulate grpcio-tools wget
+          # TensorFlow 2.15 installs protobuf 4.x, so keep Google API protos compatible.
+          pip install pyarrow "ray[train,default]==${{ matrix.ray-version }}" \
+            "googleapis-common-protos==1.75.0" tqdm pytest tabulate grpcio-tools wget
           pip install "xgboost_ray[default]<=0.1.13"
           pip install "xgboost<=2.0.3"
           pip install torchmetrics
@@ -98,6 +100,7 @@ jobs:
           pip install pyspark==${{ matrix.spark-version }}
           ./build.sh
           pip install "$(ls dist/raydp-*.whl)[tensorflow]"
+          python -c "from google.rpc import code_pb2"
       - name: Lint
         run: |
           pip install pylint==3.2.7

--- a/core/raydp-main/pom.xml
+++ b/core/raydp-main/pom.xml
@@ -223,7 +223,9 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.7</version>
+        <!-- 2.7 predates the JUnit Platform provider and silently auto-detects the TestNG
+             provider instead, so JUnit 5 tests are never discovered. -->
+        <version>3.5.4</version>
       </plugin>
 
 <!--      <plugin>-->

--- a/core/raydp-main/src/main/scala/org/apache/spark/deploy/raydp/ApplicationInfo.scala
+++ b/core/raydp-main/src/main/scala/org/apache/spark/deploy/raydp/ApplicationInfo.scala
@@ -58,8 +58,6 @@ private[spark] class ApplicationInfo(
   var coresGranted: Int = _
   var endTime: Long = _
   private var nextExecutorId: Int = _
-  // this only count those registered executors and minus removed executors
-  private var registeredExecutors: Int = 0
   // Desired executor target comes from the Spark driver. Actor handles track the Ray actor
   // slots AppMaster still owns, independent of transient Spark executor generations.
   private var desiredExecutors: Int = _
@@ -116,7 +114,6 @@ private[spark] class ApplicationInfo(
         false
       } else {
         executors(executorId).registered = true
-        registeredExecutors += 1
         true
       }
     } else {
@@ -140,9 +137,6 @@ private[spark] class ApplicationInfo(
   def kill(executorId: String, shutdownActor: Boolean): Boolean = {
     if (executors.contains(executorId)) {
       val exec = executors(executorId)
-      if (exec.registered) {
-        registeredExecutors -= 1
-      }
       removedExecutors += exec
       executors -= executorId
       executorIdToActorId -= executorId
@@ -171,14 +165,6 @@ private[spark] class ApplicationInfo(
   def getExecutorHandler(
       executorId: String): Option[ActorHandle[RayDPExecutor]] = {
     executorIdToActorId.get(executorId).flatMap(actorIdToHandle.get)
-  }
-
-  def remainingUnRegisteredExecutors(): Int = {
-    desc.numExecutors - registeredExecutors
-  }
-
-  def currentExecutors(): Int = {
-    registeredExecutors
   }
 
   def getNextExecutorId(): Int = {

--- a/core/raydp-main/src/main/scala/org/apache/spark/deploy/raydp/ApplicationInfo.scala
+++ b/core/raydp-main/src/main/scala/org/apache/spark/deploy/raydp/ApplicationInfo.scala
@@ -39,7 +39,13 @@ case class ExecutorDesc(
     memoryPerExecutorMB: Int,
     resources: Map[String, ResourceInformation]) {
   var registered: Boolean = false
+  var address: Option[RpcAddress] = None
 }
+
+private[spark] class ExecutorActorSlot(
+    var handle: ActorHandle[RayDPExecutor],
+    var currentExecutorId: Option[String],
+    var previousExecutorId: Option[String])
 
 private[spark] class ApplicationInfo(
     val startTime: Long,
@@ -52,8 +58,9 @@ private[spark] class ApplicationInfo(
   var state: ApplicationState.Value = _
   var executors: HashMap[String, ExecutorDesc] = _
   var addressToExecutorId: HashMap[RpcAddress, String] = _
+  // Resolves both current executor ids and the previous-generation tombstone to an actor slot.
   var executorIdToActorId: HashMap[String, String] = _
-  var actorIdToHandle: HashMap[String, ActorHandle[RayDPExecutor]] = _
+  var actorSlots: HashMap[String, ExecutorActorSlot] = _
   var removedExecutors: ArrayBuffer[ExecutorDesc] = _
   var coresGranted: Int = _
   var endTime: Long = _
@@ -69,7 +76,7 @@ private[spark] class ApplicationInfo(
     executors = new HashMap[String, ExecutorDesc]
     addressToExecutorId = new HashMap[RpcAddress, String]
     executorIdToActorId = new HashMap[String, String]
-    actorIdToHandle = new HashMap[String, ActorHandle[RayDPExecutor]]
+    actorSlots = new HashMap[String, ExecutorActorSlot]
     endTime = -1L
     nextExecutorId = 0
     desiredExecutors = desc.numExecutors
@@ -84,9 +91,13 @@ private[spark] class ApplicationInfo(
       memoryInMB: Int): Unit = {
     // Adding a pending executor also declares that its Ray actor slot is still active.
     // For restarted executors, actorId points back to the original named Ray actor.
-    actorIdToHandle(actorId) = handler
+    val slot = actorSlots.getOrElseUpdate(
+      actorId, new ExecutorActorSlot(handler, None, None))
+    slot.handle = handler
+    slot.currentExecutorId = Some(executorId)
     val desc = ExecutorDesc(executorId, actorId, cores, memoryInMB, null)
     executors(executorId) = desc
+    // Keep the previous generation mapping until the next disconnect or explicit actor shutdown.
     executorIdToActorId(executorId) = actorId
   }
 
@@ -95,7 +106,7 @@ private[spark] class ApplicationInfo(
   }
 
   def numActorsToAdd: Int = {
-    math.max(0, desiredExecutors - actorIdToHandle.size)
+    math.max(0, desiredExecutors - actorSlots.size)
   }
 
   // Compatibility view for ObjectStoreWriter: map restarted Spark executor ids back to
@@ -123,28 +134,33 @@ private[spark] class ApplicationInfo(
   }
 
   def markExecutorStarted(executorId: String, address: RpcAddress): Unit = {
-    addressToExecutorId(address) = executorId
-  }
-
-  def kill(address: RpcAddress, shutdownActor: Boolean): Boolean = {
-    if (addressToExecutorId.contains(address)) {
-      kill(addressToExecutorId(address), shutdownActor)
-    } else {
-      false
+    executors.get(executorId).foreach { exec =>
+      exec.address = Some(address)
+      addressToExecutorId(address) = executorId
     }
   }
 
+  def kill(address: RpcAddress, shutdownActor: Boolean): Boolean = {
+    addressToExecutorId.get(address).exists(kill(_, shutdownActor))
+  }
+
   def kill(executorId: String, shutdownActor: Boolean): Boolean = {
-    if (executors.contains(executorId)) {
-      val exec = executors(executorId)
-      removedExecutors += exec
-      executors -= executorId
-      executorIdToActorId -= executorId
-      coresGranted -= exec.cores
+    val actorIdOpt = executorIdToActorId.get(executorId)
+
+    actorIdOpt.foreach { actorId =>
       if (shutdownActor) {
+        // executorId may be a tombstone. Retire every generation mapped to the same actor so a
+        // late kill cannot leave its current generation or actor slot behind.
+        val slotOpt = actorSlots.remove(actorId)
+        val executorIds = slotOpt.map { slot =>
+          Set(executorId) ++ slot.currentExecutorId ++ slot.previousExecutorId
+        }.getOrElse(Set(executorId))
+        executorIds.foreach { id =>
+          removeExecutorGeneration(id)
+          executorIdToActorId.remove(id)
+        }
         // Only explicit Spark/AppMaster shutdown releases the Ray actor slot. A disconnect caused
         // by actor failure keeps the slot so Ray can restart it and register a new executor id.
-        val handlerOpt = actorIdToHandle.remove(exec.actorId)
         // Previously we used to exitExecutor for all scenarios, but it will cause
         // the following issue when a executor is down because of OOM issue:
         // - Executor E1 dies at T0 lets say because of OOm
@@ -154,17 +170,34 @@ private[spark] class ApplicationInfo(
         // - The failed task (stop task) gets retried as there are task retries configured.
         // - The stop task gets fired on the new executor which got recovered
         // - The Recovered executor exits with status as user intended exit.
-        handlerOpt.foreach(handle => RayExecutorUtils.exitExecutor(handle))
+        slotOpt.foreach(slot => RayExecutorUtils.exitExecutor(slot.handle))
+      } else {
+        removeExecutorGeneration(executorId)
+        actorSlots.get(actorId).foreach { slot =>
+          if (slot.currentExecutorId.contains(executorId)) {
+            // Replace the older tombstone so restart history stays bounded to one generation.
+            slot.previousExecutorId.foreach(executorIdToActorId.remove)
+            slot.currentExecutorId = None
+            slot.previousExecutorId = Some(executorId)
+          }
+        }
+        executorIdToActorId(executorId) = actorId
       }
-      true
-    } else {
-      false
+    }
+    actorIdOpt.isDefined
+  }
+
+  private def removeExecutorGeneration(executorId: String): Unit = {
+    executors.remove(executorId).foreach { exec =>
+      removedExecutors += exec
+      coresGranted -= exec.cores
+      exec.address.foreach(addressToExecutorId.remove)
     }
   }
 
   def getExecutorHandler(
       executorId: String): Option[ActorHandle[RayDPExecutor]] = {
-    executorIdToActorId.get(executorId).flatMap(actorIdToHandle.get)
+    executorIdToActorId.get(executorId).flatMap(actorSlots.get).map(_.handle)
   }
 
   def getNextExecutorId(): Int = {

--- a/core/raydp-main/src/main/scala/org/apache/spark/deploy/raydp/ApplicationInfo.scala
+++ b/core/raydp-main/src/main/scala/org/apache/spark/deploy/raydp/ApplicationInfo.scala
@@ -19,7 +19,7 @@ package org.apache.spark.deploy.raydp
 
 import java.util.Date
 
-import scala.collection.mutable.{ArrayBuffer, HashMap, HashSet}
+import scala.collection.mutable.{ArrayBuffer, HashMap}
 
 import io.ray.api.ActorHandle
 
@@ -52,17 +52,17 @@ private[spark] class ApplicationInfo(
   var state: ApplicationState.Value = _
   var executors: HashMap[String, ExecutorDesc] = _
   var addressToExecutorId: HashMap[RpcAddress, String] = _
-  var executorIdToHandler: HashMap[String, ActorHandle[RayDPExecutor]] = _
+  var executorIdToActorId: HashMap[String, String] = _
+  var actorIdToHandle: HashMap[String, ActorHandle[RayDPExecutor]] = _
   var removedExecutors: ArrayBuffer[ExecutorDesc] = _
   var coresGranted: Int = _
   var endTime: Long = _
   private var nextExecutorId: Int = _
   // this only count those registered executors and minus removed executors
   private var registeredExecutors: Int = 0
-  // Desired executor target comes from the Spark driver. Actor slots track the Ray actors
-  // AppMaster still owns, independent of transient Spark executor generations.
+  // Desired executor target comes from the Spark driver. Actor handles track the Ray actor
+  // slots AppMaster still owns, independent of transient Spark executor generations.
   private var desiredExecutors: Int = _
-  private var actorSlots: HashSet[String] = _
 
   init()
 
@@ -70,11 +70,11 @@ private[spark] class ApplicationInfo(
     state = ApplicationState.WAITING
     executors = new HashMap[String, ExecutorDesc]
     addressToExecutorId = new HashMap[RpcAddress, String]
-    executorIdToHandler = new HashMap[String, ActorHandle[RayDPExecutor]]
+    executorIdToActorId = new HashMap[String, String]
+    actorIdToHandle = new HashMap[String, ActorHandle[RayDPExecutor]]
     endTime = -1L
     nextExecutorId = 0
     desiredExecutors = desc.numExecutors
-    actorSlots = new HashSet[String]
     removedExecutors = new ArrayBuffer[ExecutorDesc]
   }
 
@@ -86,26 +86,18 @@ private[spark] class ApplicationInfo(
       memoryInMB: Int): Unit = {
     // Adding a pending executor also declares that its Ray actor slot is still active.
     // For restarted executors, actorId points back to the original named Ray actor.
-    actorSlots += actorId
+    actorIdToHandle(actorId) = handler
     val desc = ExecutorDesc(executorId, actorId, cores, memoryInMB, null)
     executors(executorId) = desc
-    executorIdToHandler(executorId) = handler
+    executorIdToActorId(executorId) = actorId
   }
 
   def updateDesiredExecutors(numExecutors: Int): Unit = {
     desiredExecutors = math.max(0, numExecutors)
   }
 
-  def hasActorSlot(actorId: String): Boolean = {
-    actorSlots.contains(actorId)
-  }
-
-  def actorSlotCount: Int = {
-    actorSlots.size
-  }
-
   def numActorsToAdd: Int = {
-    math.max(0, desiredExecutors - actorSlots.size)
+    math.max(0, desiredExecutors - actorIdToHandle.size)
   }
 
   // Compatibility view for ObjectStoreWriter: map restarted Spark executor ids back to
@@ -151,13 +143,14 @@ private[spark] class ApplicationInfo(
       if (exec.registered) {
         registeredExecutors -= 1
       }
-      removedExecutors += executors(executorId)
+      removedExecutors += exec
       executors -= executorId
+      executorIdToActorId -= executorId
       coresGranted -= exec.cores
       if (shutdownActor) {
         // Only explicit Spark/AppMaster shutdown releases the Ray actor slot. A disconnect caused
         // by actor failure keeps the slot so Ray can restart it and register a new executor id.
-        actorSlots -= exec.actorId
+        val handlerOpt = actorIdToHandle.remove(exec.actorId)
         // Previously we used to exitExecutor for all scenarios, but it will cause
         // the following issue when a executor is down because of OOM issue:
         // - Executor E1 dies at T0 lets say because of OOm
@@ -167,9 +160,8 @@ private[spark] class ApplicationInfo(
         // - The failed task (stop task) gets retried as there are task retries configured.
         // - The stop task gets fired on the new executor which got recovered
         // - The Recovered executor exits with status as user intended exit.
-        RayExecutorUtils.exitExecutor(executorIdToHandler(executorId))
+        handlerOpt.foreach(handle => RayExecutorUtils.exitExecutor(handle))
       }
-      executorIdToHandler -= executorId
       true
     } else {
       false
@@ -178,7 +170,7 @@ private[spark] class ApplicationInfo(
 
   def getExecutorHandler(
       executorId: String): Option[ActorHandle[RayDPExecutor]] = {
-    executorIdToHandler.get(executorId)
+    executorIdToActorId.get(executorId).flatMap(actorIdToHandle.get)
   }
 
   def remainingUnRegisteredExecutors(): Int = {

--- a/core/raydp-main/src/main/scala/org/apache/spark/deploy/raydp/ApplicationInfo.scala
+++ b/core/raydp-main/src/main/scala/org/apache/spark/deploy/raydp/ApplicationInfo.scala
@@ -183,7 +183,7 @@ private[spark] class ApplicationInfo(
             // - The failed task (stop task) gets retried as there are task retries configured.
             // - The stop task gets fired on the new executor which got recovered
             // - The Recovered executor exits with status as user intended exit.
-            slotOpt.foreach(slot => RayExecutorUtils.exitExecutor(slot.handle))
+            slotOpt.foreach(slot => exitExecutorActor(slot.handle))
             None
         }
       } else {
@@ -208,6 +208,12 @@ private[spark] class ApplicationInfo(
       coresGranted -= exec.cores
       exec.address.foreach(addressToExecutorId.remove)
     }
+  }
+
+  // Visible for testing. Shutting an executor down needs a live Ray actor handle, which unit
+  // tests cannot construct, so the Ray call is isolated behind this method.
+  protected def exitExecutorActor(handle: ActorHandle[RayDPExecutor]): Unit = {
+    RayExecutorUtils.exitExecutor(handle)
   }
 
   def getExecutorHandler(

--- a/core/raydp-main/src/main/scala/org/apache/spark/deploy/raydp/ApplicationInfo.scala
+++ b/core/raydp-main/src/main/scala/org/apache/spark/deploy/raydp/ApplicationInfo.scala
@@ -149,28 +149,43 @@ private[spark] class ApplicationInfo(
 
     actorIdOpt.foreach { actorId =>
       if (shutdownActor) {
-        // executorId may be a tombstone. Retire every generation mapped to the same actor so a
-        // late kill cannot leave its current generation or actor slot behind.
-        val slotOpt = actorSlots.remove(actorId)
-        val executorIds = slotOpt.map { slot =>
-          Set(executorId) ++ slot.currentExecutorId ++ slot.previousExecutorId
-        }.getOrElse(Set(executorId))
-        executorIds.foreach { id =>
-          removeExecutorGeneration(id)
-          executorIdToActorId.remove(id)
+        // One pass over the slot decides whether it survives this kill.
+        actorSlots.updateWith(actorId) {
+          // A tombstone whose actor has already re-registered refers to a generation Spark itself
+          // removed on disconnect. Spark tracks the newer generation as a separate executor, so a
+          // late kill for the retired id must not terminate it: drop only the tombstone and keep
+          // the slot so Spark can kill that generation through its own executor id.
+          case Some(slot) if slot.currentExecutorId.exists(_ != executorId) =>
+            executorIdToActorId.remove(executorId)
+            if (slot.previousExecutorId.contains(executorId)) {
+              slot.previousExecutorId = None
+            }
+            Some(slot)
+          // Otherwise no live generation remains, so retire every generation mapped to the actor
+          // and release the slot.
+          case slotOpt =>
+            val executorIds = slotOpt.map { slot =>
+              Set(executorId) ++ slot.currentExecutorId ++ slot.previousExecutorId
+            }.getOrElse(Set(executorId))
+            executorIds.foreach { id =>
+              removeExecutorGeneration(id)
+              executorIdToActorId.remove(id)
+            }
+            // Only explicit Spark/AppMaster shutdown releases the Ray actor slot. A disconnect
+            // caused by actor failure keeps the slot so Ray can restart it and register a new
+            // executor id.
+            // Previously we used to exitExecutor for all scenarios, but it will cause
+            // the following issue when a executor is down because of OOM issue:
+            // - Executor E1 dies at T0 lets say because of OOm
+            // - We try to kill it by firing stop call on E1 actor
+            // - Since the actor is not available, the stop task fails for E1
+            // - In the mean while, ray brings up the lost executor E1
+            // - The failed task (stop task) gets retried as there are task retries configured.
+            // - The stop task gets fired on the new executor which got recovered
+            // - The Recovered executor exits with status as user intended exit.
+            slotOpt.foreach(slot => RayExecutorUtils.exitExecutor(slot.handle))
+            None
         }
-        // Only explicit Spark/AppMaster shutdown releases the Ray actor slot. A disconnect caused
-        // by actor failure keeps the slot so Ray can restart it and register a new executor id.
-        // Previously we used to exitExecutor for all scenarios, but it will cause
-        // the following issue when a executor is down because of OOM issue:
-        // - Executor E1 dies at T0 lets say because of OOm
-        // - We try to kill it by firing stop call on E1 actor
-        // - Since the actor is not available, the stop task fails for E1
-        // - In the mean while, ray brings up the lost executor E1
-        // - The failed task (stop task) gets retried as there are task retries configured.
-        // - The stop task gets fired on the new executor which got recovered
-        // - The Recovered executor exits with status as user intended exit.
-        slotOpt.foreach(slot => RayExecutorUtils.exitExecutor(slot.handle))
       } else {
         removeExecutorGeneration(executorId)
         actorSlots.get(actorId).foreach { slot =>

--- a/core/raydp-main/src/main/scala/org/apache/spark/deploy/raydp/ApplicationInfo.scala
+++ b/core/raydp-main/src/main/scala/org/apache/spark/deploy/raydp/ApplicationInfo.scala
@@ -19,7 +19,7 @@ package org.apache.spark.deploy.raydp
 
 import java.util.Date
 
-import scala.collection.mutable.{ArrayBuffer, HashMap}
+import scala.collection.mutable.{ArrayBuffer, HashMap, HashSet}
 
 import io.ray.api.ActorHandle
 
@@ -32,6 +32,9 @@ import org.apache.spark.rpc.{RpcAddress, RpcEndpointRef}
 
 case class ExecutorDesc(
     executorId: String,
+    // Ray actors keep their original actor id across restarts, while Spark assigns a new
+    // executor id for each restarted executor generation.
+    actorId: String,
     cores: Int,
     memoryPerExecutorMB: Int,
     resources: Map[String, ResourceInformation]) {
@@ -56,6 +59,10 @@ private[spark] class ApplicationInfo(
   private var nextExecutorId: Int = _
   // this only count those registered executors and minus removed executors
   private var registeredExecutors: Int = 0
+  // Desired executor target comes from the Spark driver. Actor slots track the Ray actors
+  // AppMaster still owns, independent of transient Spark executor generations.
+  private var desiredExecutors: Int = _
+  private var actorSlots: HashSet[String] = _
 
   init()
 
@@ -66,17 +73,48 @@ private[spark] class ApplicationInfo(
     executorIdToHandler = new HashMap[String, ActorHandle[RayDPExecutor]]
     endTime = -1L
     nextExecutorId = 0
+    desiredExecutors = desc.numExecutors
+    actorSlots = new HashSet[String]
     removedExecutors = new ArrayBuffer[ExecutorDesc]
   }
 
   def addPendingRegisterExecutor(
       executorId: String,
+      actorId: String,
       handler: ActorHandle[RayDPExecutor],
       cores: Int,
       memoryInMB: Int): Unit = {
-    val desc = ExecutorDesc(executorId, cores, memoryInMB, null)
+    // Adding a pending executor also declares that its Ray actor slot is still active.
+    // For restarted executors, actorId points back to the original named Ray actor.
+    actorSlots += actorId
+    val desc = ExecutorDesc(executorId, actorId, cores, memoryInMB, null)
     executors(executorId) = desc
     executorIdToHandler(executorId) = handler
+  }
+
+  def updateDesiredExecutors(numExecutors: Int): Unit = {
+    desiredExecutors = math.max(0, numExecutors)
+  }
+
+  def hasActorSlot(actorId: String): Boolean = {
+    actorSlots.contains(actorId)
+  }
+
+  def actorSlotCount: Int = {
+    actorSlots.size
+  }
+
+  def numActorsToAdd: Int = {
+    math.max(0, desiredExecutors - actorSlots.size)
+  }
+
+  // Compatibility view for ObjectStoreWriter: map restarted Spark executor ids back to
+  // the original Ray actor ids used in named actor lookup.
+  def getRestartedExecutors: Map[String, String] = {
+    executors.collect {
+      case (executorId, desc) if desc.actorId != executorId =>
+        executorId -> desc.actorId
+    }.toMap
   }
 
   def registerExecutor(executorId: String): Boolean = {
@@ -117,6 +155,9 @@ private[spark] class ApplicationInfo(
       executors -= executorId
       coresGranted -= exec.cores
       if (shutdownActor) {
+        // Only explicit Spark/AppMaster shutdown releases the Ray actor slot. A disconnect caused
+        // by actor failure keeps the slot so Ray can restart it and register a new executor id.
+        actorSlots -= exec.actorId
         // Previously we used to exitExecutor for all scenarios, but it will cause
         // the following issue when a executor is down because of OOM issue:
         // - Executor E1 dies at T0 lets say because of OOm

--- a/core/raydp-main/src/main/scala/org/apache/spark/deploy/raydp/Messages.scala
+++ b/core/raydp-main/src/main/scala/org/apache/spark/deploy/raydp/Messages.scala
@@ -36,7 +36,7 @@ case class RequestExecutors(appId: String, requestedTotal: Int) extends RayDPDep
 
 case class KillExecutors(appId: String, executorIds: Seq[String]) extends RayDPDeployMessage
 
-case class RequestAddPendingRestartedExecutor(executorId: String)
+case class RequestAddPendingRestartedExecutor(actorId: String)
   extends RayDPDeployMessage
 
 case class AddPendingRestartedExecutorReply(newExecutorId: Option[String])

--- a/core/raydp-main/src/main/scala/org/apache/spark/deploy/raydp/Messages.scala
+++ b/core/raydp-main/src/main/scala/org/apache/spark/deploy/raydp/Messages.scala
@@ -36,6 +36,8 @@ case class RequestExecutors(appId: String, requestedTotal: Int) extends RayDPDep
 
 case class KillExecutors(appId: String, executorIds: Seq[String]) extends RayDPDeployMessage
 
+case object GetRestartedExecutors extends RayDPDeployMessage
+
 case class RequestAddPendingRestartedExecutor(actorId: String)
   extends RayDPDeployMessage
 

--- a/core/raydp-main/src/main/scala/org/apache/spark/deploy/raydp/RayAppMaster.scala
+++ b/core/raydp-main/src/main/scala/org/apache/spark/deploy/raydp/RayAppMaster.scala
@@ -84,11 +84,11 @@ class RayAppMaster(host: String,
   }
 
   def getRestartedExecutors(): java.util.Map[String, String] = {
-    val endpoint = appMasterEndpoint
-    if (endpoint == null) {
+    val endpointRef = endpoint
+    if (endpointRef == null) {
       Map.empty[String, String].asJava
     } else {
-      endpoint.getRestartedExecutors().asJava
+      endpointRef.askSync[Map[String, String]](GetRestartedExecutors).asJava
     }
   }
 
@@ -105,7 +105,6 @@ class RayAppMaster(host: String,
     if (rpcEnv != null) {
       rpcEnv.shutdown()
       endpoint = null
-      appMasterEndpoint = null
       rpcEnv = null
     }
     0
@@ -138,14 +137,6 @@ class RayAppMaster(host: String,
       }
 
     private var currentBundleIndex: Int = 0
-
-    def getRestartedExecutors(): Map[String, String] = {
-      if (appInfo == null) {
-        Map.empty
-      } else {
-        appInfo.getRestartedExecutors
-      }
-    }
 
     override def receive: PartialFunction[Any, Unit] = {
       case RegisterApplication(appDescription: ApplicationDescription, driver: RpcEndpointRef) =>
@@ -187,6 +178,9 @@ class RayAppMaster(host: String,
       case ExecutorStarted(executorId) =>
         appInfo.markExecutorStarted(executorId, context.senderAddress)
         context.reply(true)
+
+      case GetRestartedExecutors =>
+        context.reply(if (appInfo == null) Map.empty else appInfo.getRestartedExecutors)
 
       case RequestExecutors(appId, requestedTotal) =>
         assert(appInfo != null && appInfo.id == appId)
@@ -271,6 +265,8 @@ class RayAppMaster(host: String,
     private def reconcileExecutors(): Unit = {
       // Reconcile against Ray actor slots, not registered Spark executor generations.
       // Restarted actors keep the same slot and only receive a new Spark executor id.
+      // DesiredExecutors is the single source of truth and the only bound on actor provisioning.
+      // So any future bug in spark's desiredExecutors tracking could provision unbounded actors.
       (0 until appInfo.numActorsToAdd).foreach { _ =>
         requestNewExecutor()
       }

--- a/core/raydp-main/src/main/scala/org/apache/spark/deploy/raydp/RayAppMaster.scala
+++ b/core/raydp-main/src/main/scala/org/apache/spark/deploy/raydp/RayAppMaster.scala
@@ -203,21 +203,21 @@ class RayAppMaster(host: String,
         }
         context.reply(success)
 
-      case RequestAddPendingRestartedExecutor(executorId) =>
+      case RequestAddPendingRestartedExecutor(actorId) =>
         val cores = appInfo.desc.coresPerExecutor.getOrElse(1)
         val memory = appInfo.desc.memoryPerExecutorMB
         // ray actor will restart using the old ID
-        val handlerOpt = Ray.getActor("raydp-executor-" + executorId)
+        val handlerOpt = Ray.getActor("raydp-executor-" + actorId)
         if (!handlerOpt.isPresent) {
           context.reply(AddPendingRestartedExecutorReply(None))
-        } else if (!appInfo.hasActorSlot(executorId)) {
+        } else if (!appInfo.actorIdToHandle.contains(actorId)) {
           // The actor may still be visible in Ray after Spark has scaled the slot down.
           // Do not allow a late restart request to recreate a removed executor.
           context.reply(AddPendingRestartedExecutorReply(None))
         } else {
           val newExecutorId = s"${appInfo.getNextExecutorId()}"
           val handler = handlerOpt.get.asInstanceOf[ActorHandle[RayDPExecutor]]
-          appInfo.addPendingRegisterExecutor(newExecutorId, executorId, handler, cores, memory)
+          appInfo.addPendingRegisterExecutor(newExecutorId, actorId, handler, cores, memory)
           context.reply(AddPendingRestartedExecutorReply(Some(newExecutorId)))
         }
     }

--- a/core/raydp-main/src/main/scala/org/apache/spark/deploy/raydp/RayAppMaster.scala
+++ b/core/raydp-main/src/main/scala/org/apache/spark/deploy/raydp/RayAppMaster.scala
@@ -84,10 +84,11 @@ class RayAppMaster(host: String,
   }
 
   def getRestartedExecutors(): java.util.Map[String, String] = {
-    if (appMasterEndpoint == null) {
+    val endpoint = appMasterEndpoint
+    if (endpoint == null) {
       Map.empty[String, String].asJava
     } else {
-      appMasterEndpoint.getRestartedExecutors().asJava
+      endpoint.getRestartedExecutors().asJava
     }
   }
 

--- a/core/raydp-main/src/main/scala/org/apache/spark/deploy/raydp/RayAppMaster.scala
+++ b/core/raydp-main/src/main/scala/org/apache/spark/deploy/raydp/RayAppMaster.scala
@@ -44,9 +44,9 @@ class RayAppMaster(host: String,
                    port: Int,
                    actorExtraClasspath: String) extends Serializable with Logging {
   private var endpoint: RpcEndpointRef = _
+  private var appMasterEndpoint: RayAppMasterEndpoint = _
   private var rpcEnv: RpcEnv = _
   private val conf: SparkConf = new SparkConf()
-  private val restartedExecutors = new HashMap[String, String]()
 
   init()
 
@@ -71,7 +71,8 @@ class RayAppMaster(host: String,
       numUsableCores = 0,
       clientMode = false)
     // register endpoint
-    endpoint = rpcEnv.setupEndpoint(RayAppMaster.ENDPOINT_NAME, new RayAppMasterEndpoint(rpcEnv))
+    appMasterEndpoint = new RayAppMasterEndpoint(rpcEnv)
+    endpoint = rpcEnv.setupEndpoint(RayAppMaster.ENDPOINT_NAME, appMasterEndpoint)
   }
 
   /**
@@ -82,7 +83,13 @@ class RayAppMaster(host: String,
     RpcEndpointAddress(rpcEnv.address, RayAppMaster.ENDPOINT_NAME).toString
   }
 
-  def getRestartedExecutors(): java.util.Map[String, String] = restartedExecutors.asJava
+  def getRestartedExecutors(): java.util.Map[String, String] = {
+    if (appMasterEndpoint == null) {
+      Map.empty[String, String].asJava
+    } else {
+      appMasterEndpoint.getRestartedExecutors().asJava
+    }
+  }
 
   /**
    * This is used to represent the Spark on Ray cluster URL.
@@ -97,6 +104,7 @@ class RayAppMaster(host: String,
     if (rpcEnv != null) {
       rpcEnv.shutdown()
       endpoint = null
+      appMasterEndpoint = null
       rpcEnv = null
     }
     0
@@ -129,6 +137,14 @@ class RayAppMaster(host: String,
       }
 
     private var currentBundleIndex: Int = 0
+
+    def getRestartedExecutors(): Map[String, String] = {
+      if (appInfo == null) {
+        Map.empty
+      } else {
+        appInfo.getRestartedExecutors
+      }
+    }
 
     override def receive: PartialFunction[Any, Unit] = {
       case RegisterApplication(appDescription: ApplicationDescription, driver: RpcEndpointRef) =>
@@ -173,11 +189,8 @@ class RayAppMaster(host: String,
 
       case RequestExecutors(appId, requestedTotal) =>
         assert(appInfo != null && appInfo.id == appId)
-        if (requestedTotal > appInfo.currentExecutors()) {
-          (0 until (requestedTotal - appInfo.currentExecutors())).foreach{ _ =>
-            requestNewExecutor()
-          }
-        }
+        appInfo.updateDesiredExecutors(requestedTotal)
+        reconcileExecutors()
         context.reply(true)
 
       case KillExecutors(appId, executorIds) =>
@@ -191,22 +204,21 @@ class RayAppMaster(host: String,
         context.reply(success)
 
       case RequestAddPendingRestartedExecutor(executorId) =>
-        if (appInfo.remainingUnRegisteredExecutors > 0) {
-          val cores = appInfo.desc.coresPerExecutor.getOrElse(1)
-          val memory = appInfo.desc.memoryPerExecutorMB
-          // ray actor will restart using the old ID
-          val handlerOpt = Ray.getActor("raydp-executor-" + executorId)
-          if (!handlerOpt.isPresent) {
-            context.reply(AddPendingRestartedExecutorReply(None))
-          } else {
-            val newExecutorId = s"${appInfo.getNextExecutorId()}"
-            val handler = handlerOpt.get.asInstanceOf[ActorHandle[RayDPExecutor]]
-            appInfo.addPendingRegisterExecutor(newExecutorId, handler, cores, memory)
-            restartedExecutors(newExecutorId) = executorId
-            context.reply(AddPendingRestartedExecutorReply(Some(newExecutorId)))
-          }
-        } else {
+        val cores = appInfo.desc.coresPerExecutor.getOrElse(1)
+        val memory = appInfo.desc.memoryPerExecutorMB
+        // ray actor will restart using the old ID
+        val handlerOpt = Ray.getActor("raydp-executor-" + executorId)
+        if (!handlerOpt.isPresent) {
           context.reply(AddPendingRestartedExecutorReply(None))
+        } else if (!appInfo.hasActorSlot(executorId)) {
+          // The actor may still be visible in Ray after Spark has scaled the slot down.
+          // Do not allow a late restart request to recreate a removed executor.
+          context.reply(AddPendingRestartedExecutorReply(None))
+        } else {
+          val newExecutorId = s"${appInfo.getNextExecutorId()}"
+          val handler = handlerOpt.get.asInstanceOf[ActorHandle[RayDPExecutor]]
+          appInfo.addPendingRegisterExecutor(newExecutorId, executorId, handler, cores, memory)
+          context.reply(AddPendingRestartedExecutorReply(Some(newExecutorId)))
         }
     }
 
@@ -224,7 +236,8 @@ class RayAppMaster(host: String,
     }
 
     private def createApplication(
-        desc: ApplicationDescription, driver: RpcEndpointRef): ApplicationInfo = {
+        desc: ApplicationDescription,
+        driver: RpcEndpointRef): ApplicationInfo = {
       val now = System.currentTimeMillis()
       val date = new Date(now)
       val appId = newApplicationId(date)
@@ -250,8 +263,13 @@ class RayAppMaster(host: String,
     }
 
     private def schedule(): Unit = {
-      val desc = appInfo.desc
-      for (_ <- 0 until desc.numExecutors) {
+      reconcileExecutors()
+    }
+
+    private def reconcileExecutors(): Unit = {
+      // Reconcile against Ray actor slots, not registered Spark executor generations.
+      // Restarted actors keep the same slot and only receive a new Spark executor id.
+      (0 until appInfo.numActorsToAdd).foreach { _ =>
         requestNewExecutor()
       }
     }
@@ -271,23 +289,6 @@ class RayAppMaster(host: String,
             .map { case (name, amount) => s"$name: $amount" }.mkString(", ")} }..")
       // TODO: Support generic fractional logical resources using prefix spark.ray.actor.resource.*
 
-      // This will check with dynamic auto scale no additional pending executor actor added more
-      // than max executors count as this result in executor even running after job completion
-      val dynamicAllocationEnabled = conf.getBoolean("spark.dynamicAllocation.enabled", false)
-      // FIX: Check total executors (current + restarted) against maxExecutor, executorInstances
-      if (dynamicAllocationEnabled) {
-        val maxExecutor = conf.getInt("spark.dynamicAllocation.maxExecutors", 0)
-        if ((appInfo.executors.size + restartedExecutors.size) >= maxExecutor) {
-          return
-        }
-      } else {
-        val executorInstances = conf.getInt("spark.executor.instances", 0)
-        if (executorInstances != 0 &&
-          (appInfo.executors.size + restartedExecutors.size) >= executorInstances) {
-          return
-        }
-      }
-
       val handler = RayExecutorUtils.createExecutorActor(
         executorId,
         getAppMasterEndpointUrl(),
@@ -300,7 +301,9 @@ class RayAppMaster(host: String,
         placementGroup,
         getNextBundleIndex,
         appInfo.desc.command.javaOpts.asJava)
-      appInfo.addPendingRegisterExecutor(executorId, handler, sparkCoresPerExecutor, memory)
+      // A newly created Ray actor uses the same id for its actor slot and first Spark executor.
+      appInfo.addPendingRegisterExecutor(
+        executorId, executorId, handler, sparkCoresPerExecutor, memory)
     }
 
     private def appendActorClasspath(javaOpts: Seq[String]): Seq[String] = {

--- a/core/raydp-main/src/main/scala/org/apache/spark/deploy/raydp/RayAppMaster.scala
+++ b/core/raydp-main/src/main/scala/org/apache/spark/deploy/raydp/RayAppMaster.scala
@@ -205,7 +205,7 @@ class RayAppMaster(host: String,
         val handlerOpt = Ray.getActor("raydp-executor-" + actorId)
         if (!handlerOpt.isPresent) {
           context.reply(AddPendingRestartedExecutorReply(None))
-        } else if (!appInfo.actorIdToHandle.contains(actorId)) {
+        } else if (!appInfo.actorSlots.contains(actorId)) {
           // The actor may still be visible in Ray after Spark has scaled the slot down.
           // Do not allow a late restart request to recreate a removed executor.
           context.reply(AddPendingRestartedExecutorReply(None))

--- a/core/raydp-main/src/main/scala/org/apache/spark/deploy/raydp/RayAppMaster.scala
+++ b/core/raydp-main/src/main/scala/org/apache/spark/deploy/raydp/RayAppMaster.scala
@@ -44,7 +44,6 @@ class RayAppMaster(host: String,
                    port: Int,
                    actorExtraClasspath: String) extends Serializable with Logging {
   private var endpoint: RpcEndpointRef = _
-  private var appMasterEndpoint: RayAppMasterEndpoint = _
   private var rpcEnv: RpcEnv = _
   private val conf: SparkConf = new SparkConf()
 
@@ -71,7 +70,7 @@ class RayAppMaster(host: String,
       numUsableCores = 0,
       clientMode = false)
     // register endpoint
-    appMasterEndpoint = new RayAppMasterEndpoint(rpcEnv)
+    val appMasterEndpoint = new RayAppMasterEndpoint(rpcEnv)
     endpoint = rpcEnv.setupEndpoint(RayAppMaster.ENDPOINT_NAME, appMasterEndpoint)
   }
 

--- a/core/raydp-main/src/main/scala/org/apache/spark/deploy/raydp/RayAppMaster.scala
+++ b/core/raydp-main/src/main/scala/org/apache/spark/deploy/raydp/RayAppMaster.scala
@@ -201,6 +201,7 @@ class RayAppMaster(host: String,
             success = false
           }
         }
+        reconcileExecutors()
         context.reply(success)
 
       case RequestAddPendingRestartedExecutor(actorId) =>

--- a/core/raydp-main/src/main/scala/org/apache/spark/executor/RayDPExecutor.scala
+++ b/core/raydp-main/src/main/scala/org/apache/spark/executor/RayDPExecutor.scala
@@ -83,14 +83,17 @@ class RayDPExecutor(
     // Check if this actor is restarted
     val ifRestarted = Ray.getRuntimeContext.wasCurrentActorRestarted
     if (ifRestarted) {
+      // executorId still holds the original Ray actor name before reassignment below.
+      val originalActorId = executorId
       val reply = appMaster.askSync[AddPendingRestartedExecutorReply](
-          RequestAddPendingRestartedExecutor(executorId))
+          RequestAddPendingRestartedExecutor(originalActorId))
       // this executor might be restarted, use the returned new id and register self
       if (!reply.newExecutorId.isEmpty) {
-        logInfo(s"Executor: ${executorId} seems to be restarted, registering using new id")
+        logInfo(s"Executor: ${originalActorId} seems to be restarted, registering using new id")
         executorId = reply.newExecutorId.get
       } else {
-        throw new RuntimeException(s"Executor ${executorId} restarted, but getActor failed.")
+        throw new RuntimeException(
+          s"Executor ${originalActorId} restarted, but getActor failed.")
       }
     }
     val registeredResult = appMaster.askSync[Boolean](RegisterExecutor(executorId, nodeIp))

--- a/core/raydp-main/src/test/scala/org/apache/spark/deploy/raydp/ApplicationInfoTest.scala
+++ b/core/raydp-main/src/test/scala/org/apache/spark/deploy/raydp/ApplicationInfoTest.scala
@@ -1,0 +1,214 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.deploy.raydp
+
+import java.lang.reflect.{InvocationHandler, Method, Proxy}
+import java.util.Date
+
+import scala.collection.mutable.ArrayBuffer
+
+import io.ray.api.ActorHandle
+import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertTrue}
+import org.junit.jupiter.api.Test
+
+import org.apache.spark.executor.RayDPExecutor
+
+/**
+ * Tests for the actor-slot bookkeeping in [[ApplicationInfo]].
+ *
+ * A Ray actor keeps one logical slot across restarts while Spark assigns a new executor id to
+ * every restarted generation, so slot accounting and generation accounting have to be asserted
+ * independently. These tests drive the state machine directly, which makes the disconnect and
+ * late-kill orderings deterministic instead of racy.
+ */
+class ApplicationInfoTest {
+
+  private val Cores = 2
+  private val MemoryMB = 512
+
+  /**
+   * Records actor shutdowns rather than calling into Ray, which would need a live runtime.
+   */
+  private class TestApplicationInfo(numExecutors: Int)
+    extends ApplicationInfo(
+      startTime = 0L,
+      id = "app-test",
+      desc = ApplicationDescription(
+        name = "test",
+        numExecutors = numExecutors,
+        coresPerExecutor = Some(Cores),
+        memoryPerExecutorMB = MemoryMB,
+        rayActorCPU = 1.0,
+        command = Command("driver-url", Map.empty, Seq.empty, Seq.empty, Seq.empty)),
+      submitDate = new Date(0L),
+      driver = null) {
+
+    val exitedActors = new ArrayBuffer[String]
+
+    override protected def exitExecutorActor(handle: ActorHandle[RayDPExecutor]): Unit = {
+      exitedActors += handle.toString
+    }
+  }
+
+  /**
+   * A stand-in [[ActorHandle]] that only carries an identity. The production code under test
+   * never calls Ray methods on it because [[TestApplicationInfo]] intercepts the shutdown.
+   */
+  private def handle(actorId: String): ActorHandle[RayDPExecutor] = {
+    val invocationHandler = new InvocationHandler {
+      override def invoke(proxy: AnyRef, method: Method, args: Array[AnyRef]): AnyRef = {
+        method.getName match {
+          case "toString" => actorId
+          case "hashCode" => Integer.valueOf(System.identityHashCode(proxy))
+          case "equals" => java.lang.Boolean.valueOf(proxy eq args(0))
+          case other => throw new UnsupportedOperationException(s"$other unused in tests")
+        }
+      }
+    }
+    Proxy.newProxyInstance(
+      classOf[ActorHandle[_]].getClassLoader,
+      Array[Class[_]](classOf[ActorHandle[_]]),
+      invocationHandler).asInstanceOf[ActorHandle[RayDPExecutor]]
+  }
+
+  private def newApp(numExecutors: Int = 1): TestApplicationInfo = {
+    new TestApplicationInfo(numExecutors)
+  }
+
+  private def register(
+      app: TestApplicationInfo,
+      executorId: String,
+      actorId: String): Unit = {
+    app.addPendingRegisterExecutor(executorId, actorId, handle(actorId), Cores, MemoryMB)
+  }
+
+  @Test
+  def killReleasesTheSlotOfALiveGeneration(): Unit = {
+    val app = newApp()
+    register(app, executorId = "23", actorId = "23")
+    assertEquals(0, app.numActorsToAdd)
+
+    assertTrue(app.kill("23", shutdownActor = true))
+
+    assertTrue(app.actorSlots.isEmpty)
+    assertTrue(app.executors.isEmpty)
+    assertEquals(Seq("23"), app.exitedActors.toSeq)
+    // The slot is gone, so reconciliation has to create a replacement.
+    assertEquals(1, app.numActorsToAdd)
+  }
+
+  @Test
+  def disconnectKeepsTheSlotAndTombstonesTheGeneration(): Unit = {
+    val app = newApp()
+    register(app, executorId = "23", actorId = "23")
+
+    assertTrue(app.kill("23", shutdownActor = false))
+
+    // The Spark generation is retired but the Ray actor may still come back.
+    assertTrue(app.executors.isEmpty)
+    assertEquals(1, app.actorSlots.size)
+    assertEquals(0, app.numActorsToAdd)
+    assertTrue(app.exitedActors.isEmpty)
+    // The retired id still resolves, so a later kill can find the slot.
+    assertEquals(Some("23"), app.executorIdToActorId.get("23"))
+  }
+
+  @Test
+  def killAfterDisconnectWithoutRestartReleasesTheSlot(): Unit = {
+    val app = newApp()
+    register(app, executorId = "23", actorId = "23")
+    app.kill("23", shutdownActor = false)
+
+    // The actor has not re-registered, so this kill must still retire the slot.
+    assertTrue(app.kill("23", shutdownActor = true))
+
+    assertTrue(app.actorSlots.isEmpty)
+    assertEquals(Seq("23"), app.exitedActors.toSeq)
+    assertEquals(1, app.numActorsToAdd)
+  }
+
+  @Test
+  def lateKillDoesNotTerminateASupersededGeneration(): Unit = {
+    val app = newApp()
+    register(app, executorId = "23", actorId = "23")
+    app.kill("23", shutdownActor = false)
+    // Ray restarts the actor, which registers a new Spark generation on the same slot.
+    register(app, executorId = "1002", actorId = "23")
+
+    // A KillExecutors delayed past the restart refers to a generation Spark already removed.
+    assertTrue(app.kill("23", shutdownActor = true))
+
+    assertEquals(1, app.actorSlots.size)
+    assertTrue(app.executors.contains("1002"))
+    assertTrue(app.exitedActors.isEmpty)
+    assertEquals(0, app.numActorsToAdd)
+    // Only the stale tombstone is dropped.
+    assertFalse(app.executorIdToActorId.contains("23"))
+    assertEquals(Some("23"), app.executorIdToActorId.get("1002"))
+  }
+
+  @Test
+  def killOfALiveGenerationAlsoClearsItsTombstone(): Unit = {
+    val app = newApp()
+    register(app, executorId = "23", actorId = "23")
+    app.kill("23", shutdownActor = false)
+    register(app, executorId = "1002", actorId = "23")
+
+    assertTrue(app.kill("1002", shutdownActor = true))
+
+    assertTrue(app.actorSlots.isEmpty)
+    assertTrue(app.executors.isEmpty)
+    assertFalse(app.executorIdToActorId.contains("23"))
+    assertFalse(app.executorIdToActorId.contains("1002"))
+    assertEquals(Seq("23"), app.exitedActors.toSeq)
+    assertEquals(1, app.numActorsToAdd)
+  }
+
+  @Test
+  def restartHistoryStaysBoundedToOneRetiredGeneration(): Unit = {
+    val app = newApp()
+    register(app, executorId = "23", actorId = "23")
+    app.kill("23", shutdownActor = false)
+    register(app, executorId = "1002", actorId = "23")
+    app.kill("1002", shutdownActor = false)
+    register(app, executorId = "1003", actorId = "23")
+
+    // Two restarts must not accumulate two tombstones for the same actor.
+    assertFalse(app.executorIdToActorId.contains("23"))
+    assertEquals(Some("23"), app.executorIdToActorId.get("1002"))
+    assertEquals(Some("23"), app.executorIdToActorId.get("1003"))
+    assertEquals(1, app.actorSlots.size)
+  }
+
+  @Test
+  def restartsDoNotInflateTheSlotCount(): Unit = {
+    val app = newApp(numExecutors = 2)
+    register(app, executorId = "0", actorId = "0")
+    register(app, executorId = "1", actorId = "1")
+    assertEquals(0, app.numActorsToAdd)
+
+    // A restart changes the Spark generation, not the number of logical actors.
+    app.kill("1", shutdownActor = false)
+    register(app, executorId = "1002", actorId = "1")
+
+    assertEquals(2, app.actorSlots.size)
+    assertEquals(0, app.numActorsToAdd)
+    // The restarted generation maps back to its original actor for named-actor lookup.
+    assertEquals(Map("1002" -> "1"), app.getRestartedExecutors)
+  }
+}

--- a/python/raydp/tests/test_spark_cluster.py
+++ b/python/raydp/tests/test_spark_cluster.py
@@ -32,6 +32,18 @@ from raydp.spark.ray_cluster_master import RAYDP_SPARK_MASTER_SUFFIX
 from ray.cluster_utils import Cluster
 import ray.util.client as ray_client
 
+
+def _wait_for(value_fn, condition, timeout=60):
+    deadline = time.monotonic() + timeout
+    value = None
+    while time.monotonic() < deadline:
+        value = value_fn()
+        if condition(value):
+            return value
+        time.sleep(0.5)
+    raise AssertionError(f"Condition not met within {timeout}s; last value: {value!r}")
+
+
 @pytest.mark.parametrize("spark_on_ray_small", ["local"], indirect=True)
 def test_spark(spark_on_ray_small):
     spark = spark_on_ray_small
@@ -364,6 +376,141 @@ def test_release_spark_recoverable(jdk17_extra_spark_configs):
     raydp.stop_spark()
     ray.shutdown()
     cluster.shutdown()
+
+
+def test_restarted_executor_does_not_block_scale_up(jdk17_extra_spark_configs):
+    """Request three executors after one of the original two executor actors restarts.
+
+    The pre-fix backend counts restart history as another actor slot and remains at two.
+    The fixed backend creates one new actor and reaches three.
+    """
+    cluster = Cluster(initialize_head=True, head_node_args={"num_cpus": 1})
+    spark = None
+    try:
+        ray.init(address=cluster.address, include_dashboard=False)
+        worker_args = {
+            "num_cpus": 1,
+            "object_store_memory": 10 ** 8,
+            "resources": {"spark_executor": 1},
+        }
+
+        configs = {
+            "spark.dynamicAllocation.enabled": "true",
+            "spark.dynamicAllocation.minExecutors": "2",
+            "spark.dynamicAllocation.initialExecutors": "2",
+            "spark.dynamicAllocation.maxExecutors": "3",
+            # Satisfy Spark's dynamic-allocation validation without an external shuffle service.
+            "spark.dynamicAllocation.shuffleTracking.enabled": "true",
+            # Keep requestTotalExecutors() enabled, but stop EAM from replacing the target of 3.
+            "spark.dynamicAllocation.testing": "true",
+            "spark.testing.dynamicAllocation.schedule.enabled": "false",
+            "spark.ray.raydp_spark_executor.actor.resource.spark_executor": "1",
+            **jdk17_extra_spark_configs,
+        }
+        spark = raydp.init_spark("test_restart_scale_up", 2, 1, "500M", configs=configs)
+        jsc = spark.sparkContext._jsc.sc()
+
+        # The pre-fix backend only counts registered executors when handling Spark's initial
+        # target of 2, so it can create a third actor while RayDP's two initial actors are still
+        # pending. Record the named actors before adding executor resources.
+        actor_prefix = "raydp-executor-"
+        actor_ids = {
+            name[len(actor_prefix):]
+            for name in ray.util.list_named_actors()
+            if name.startswith(actor_prefix)
+        }
+        assert actor_ids in ({"0", "1"}, {"0", "1", "2"})
+
+        # An extra actor must register before being removed through Spark,
+        # which cleans both its Ray actor and AppMaster executor state.
+        for _ in range(3):
+            cluster.add_node(**worker_args)
+
+        def executor_ids():
+            ids = jsc.getExecutorIds()
+            return {ids.apply(i) for i in range(ids.size())}
+
+        initial_ids = _wait_for(executor_ids, lambda ids: len(ids) == len(actor_ids))
+        if len(initial_ids) == 3:
+            extra_id = max(initial_ids, key=int)
+            # remove the extra actor 
+            assert jsc.killAndReplaceExecutor(extra_id)
+            initial_ids = _wait_for(
+                executor_ids,
+                lambda ids: len(ids) == 2 and extra_id not in ids,
+            )
+
+        # Restart one of the two intended actors. With no normal actor left pending, the executor
+        # count returning to 2 means the failed actor has registered with a new Spark executor ID.
+        victim_id = next(iter(initial_ids))
+        ray.kill(ray.get_actor(f"{actor_prefix}{victim_id}"), no_restart=False)
+        _wait_for(
+            executor_ids,
+            lambda ids: len(ids) == 2 and victim_id not in ids,
+        )
+
+        empty_java_map = spark._jvm.java.util.HashMap()
+        empty_scala_map = spark._jvm.org.apache.spark.api.python.PythonUtils.toScalaMap(
+            empty_java_map)
+        # Assert that Spark accepts a total target of 3. Zero and the empty map only mean that the
+        # request has no locality hints; they do not change the requested executor count.
+        assert jsc.requestTotalExecutors(3, 0, empty_scala_map)
+        # Functional regression check: the pre-fix backend remains at 2 and times out, while the
+        # fixed backend reaches 3.
+        _wait_for(executor_ids, lambda ids: len(ids) == 3)
+    finally:
+        if spark is not None:
+            raydp.stop_spark()
+        ray.shutdown()
+        cluster.shutdown()
+
+
+def test_kill_and_replace_executor_reconciles_desired_count(jdk17_extra_spark_configs):
+    """Kill one of two executors and verify that a different executor restores the count to two.
+
+    The pre-fix backend removes the victim and stays at one. The fixed backend reconciles the
+    desired count by creating a replacement and returning to two.
+    """
+    cluster = Cluster(initialize_head=True, head_node_args={"num_cpus": 1})
+    spark = None
+    try:
+        ray.init(address=cluster.address, include_dashboard=False)
+        # Provide exactly two executor slots. Killing one frees all resources needed to replace it.
+        cluster.add_node(
+            num_cpus=2,
+            object_store_memory=10 ** 8,
+            resources={"spark_executor": 2},
+        )
+        configs = {
+            "spark.ray.raydp_spark_executor.actor.resource.spark_executor": "1",
+            **jdk17_extra_spark_configs,
+        }
+        spark = raydp.init_spark(
+            "test_kill_and_replace", 2, 1, "500M", configs=configs)
+        jsc = spark.sparkContext._jsc.sc()
+
+        def executor_ids():
+            ids = jsc.getExecutorIds()
+            return {ids.apply(i) for i in range(ids.size())}
+
+        # Verify that both requested executors are registered, then select one ID to replace.
+        initial_ids = _wait_for(executor_ids, lambda ids: len(ids) == 2)
+        victim_id = next(iter(initial_ids))
+
+        # Assert that Spark accepts the kill-and-replace request. The following wait requires both
+        # count == 2 and victim removal: the pre-fix backend times out at 1, while the fixed backend
+        # returns with a new ID.
+        assert jsc.killAndReplaceExecutor(victim_id)
+        replacement_ids = _wait_for(
+            executor_ids,
+            lambda ids: len(ids) == 2 and victim_id not in ids,
+        )
+        assert replacement_ids - initial_ids
+    finally:
+        if spark is not None:
+            raydp.stop_spark()
+        ray.shutdown()
+        cluster.shutdown()
 
 
 @pytest.mark.skip("flaky")


### PR DESCRIPTION
## What does this PR do?

The old code counted Spark executor generations instead of logical Ray actors. A restarted executor was recorded in both `executors` and `restartedExecutors`, while stale restart mappings survived executor removal. This allowed `registeredExecutors` to report a deficit while the restart-based limit check simultaneously reported that the application was full. `RequestExecutors` would then acknowledge the target without creating any actor. Tracking slots by the stable Ray `actorId` removes this contradiction: a restart changes the Spark executor generation, not the number of logical actors.

Two lifecycle details are essential to make that model correct. First, the actor-slot registry must retain an `ActorHandle` across executor disconnects; otherwise Ray's reference can be released and the non-detached actor terminated while RayDP still counts its slot. Second, RayAppMaster must reconcile after `KillExecutors`: Spark treats the requested total as persistent and expects the cluster manager, as YARN does, to replace missing executors without another identical request from the driver.

## Why is this change needed?

### Problem

RayDP previously conflated two different identities:

- A Ray actor has a stable identity and keeps the same named `actorId` across restarts.
- A Spark executor gets a new `executorId` for every restarted generation.

The previous implementation used several generation-based states to approximate the number of executor actors:

- `registeredExecutors` to calculate how many executors were missing.
- `executors.size + restartedExecutors.size` to enforce the executor limit.
- `restartedExecutors` to retain the mapping from a new executor ID to its original actor ID.

These states have different lifecycles and can disagree. In particular, a restarted executor is present in both `executors` and `restartedExecutors`, so the same Ray actor is counted twice. Moreover, entries in `restartedExecutors` are not removed when the corresponding executor generation disconnects, allowing historical restarts to remain in executor accounting.

### Failure Scenario

The incorrect count follows directly from three asymmetric code paths:

1. When a restarted actor requests a new Spark executor ID, RayAppMaster calls `addPendingRegisterExecutor(newExecutorId, ...)`, which inserts the new generation into `appInfo.executors`. It then also writes `restartedExecutors(newExecutorId) = originalActorId`.
2. Every `newExecutorId` is unique. A later restart therefore adds another map entry instead of replacing the entry for the previous generation, even though both values point to the same original Ray actor.
3. On RPC disconnect, `ApplicationInfo.kill()` removes the current generation from `appInfo.executors`. It cannot remove the matching `restartedExecutors` entry because that map is owned separately by `RayAppMaster`, and neither the disconnect path nor `KillExecutors` performs such cleanup.

The capacity check nevertheless uses:

```text
appInfo.executors.size + restartedExecutors.size
```

This is wrong in two different phases. While a restarted generation is active, its executor ID is present in both maps and is counted twice. After it disconnects, it is removed from `executors` but remains in `restartedExecutors`, so it becomes a permanently counted historical generation.

For one logical actor with original `actorId = 7`, the state evolves as follows:

| Event | `appInfo.executors` | `restartedExecutors` | Count used by limit check | Logical actor slots |
| --- | --- | --- | ---: | ---: |
| Initial generation | `{7}` | `{}` | 1 | 1 |
| Restart as executor 1001 | `{1001}` | `{1001 -> 7}` | 2 | 1 |
| Executor 1001 disconnects | `{}` | `{1001 -> 7}` | 1 | 1 |
| Restart as executor 1002 | `{1002}` | `{1001 -> 7, 1002 -> 7}` | 3 | 1 |

Thus, each restart adds another capacity unit to `restartedExecutors`, although the number of Ray actor slots never changes. Disconnecting the generation does not undo that increase.

The restart-registration path does not call `requestNewExecutor()`, so it bypasses the maximum check that later consumes this inflated count. Each disconnect also decrements `registeredExecutors`, making `remainingUnRegisteredExecutors > 0` true and admitting the next restart generation. The history can therefore grow to the configured maximum and beyond.

The key contradiction is:

> `registeredExecutors` says executors are missing, while `restartedExecutors` says the
> application is already at its limit.

Both cannot be valid measures of Ray executor capacity.

### Solution

Track logical Ray actor slots independently from Spark executor generations.

An actor slot is keyed by the original `actorId`:

- Creating a new Ray actor adds one actor slot.
- Restarting that actor creates a new Spark `executorId`, but does not add another slot.
- An executor disconnect removes only that Spark executor generation because Ray may restart the
  same actor.
- When Spark sends `KillExecutors`, RayDP removes the actor slot and requests actor shutdown.
- The Spark driver's requested total is stored as `desiredExecutors`.

These rules describe two stages that may occur in the same failure path. The AppMaster's initial RPC disconnect handling keeps the slot because Ray may recover the actor. If Spark subsequently decides to terminate that executor and sends `KillExecutors`, RayDP then removes the slot and stops the actor. Therefore slot removal is tied to the `KillExecutors` command, not only to an explicit scale-down reason.

Executor reconciliation then becomes:

```text
actorsToAdd = max(0, desiredExecutors - actorSlots)
```

This compares two values with matching semantics: the number of logical actors requested by Spark and the number of logical Ray actor slots currently owned by the application.

The implementation keeps an `actorId -> ActorHandle` registry as the actor-slot state and maps each Spark executor generation back to its stable actor ID. The restarted-executor mapping required by recoverable RDD lookup is derived from this state, but is no longer used for capacity accounting.

The actor-slot registry cannot continue to use the previous `executorIdToHandler` map. When an executor disconnects, `onDisconnected` calls `ApplicationInfo.kill(..., shutdownActor = false)` to remove that Spark executor generation while allowing Ray to restart its actor. However, `kill()` unconditionally executes `executorIdToHandler -= executorId`. Removing the executor ID also removes the map entry that retains the corresponding actor handle. If this is the last retained handle, the handle becomes unreachable and the actor can be terminated, which violates the expected restart semantics of `shutdownActor = false`.

The handle is not only a lookup convenience: it keeps Ray's reference to a non-detached actor alive. RayDP creates a named actor with `setName`, but does not give it `ActorLifetime.DETACHED`. In Ray 2.1, `NativeActorHandleReference.finalizeReferent()` calls `nativeRemoveActorHandleReference()` after a Java handle becomes unreachable. Losing the last retained handle can therefore reduce the distributed reference count to zero and terminate the actor. `setMaxRestarts(-1)` allows recovery from actor process failures; it does not make the actor independent of its owning reference.

The sharp failure sequence is:

```text
actorId = 23, current Spark executorId = 1001
executorIdToHandler(1001) = handle(23)

executor 1001 disconnects
  -> kill(1001, shutdownActor = false)
  -> actorSlots still contains 23, because Ray is expected to restart it
  -> executorIdToHandler removes 1001 unconditionally
  -> handle(23) becomes unreachable and is garbage-collected
  -> Ray removes the actor-handle reference and actor 23 can be terminated
```

RayDP is then left with a ghost slot: `actorSlots` says actor 23 exists, while the actor and its handle are gone. Because reconciliation sees the slot as present, it creates no replacement. A named actor is not sufficient protection here; naming makes lookup possible only while the actor is still alive.

For this reason, `f61f80e5e6e0daa125172573ecf4c8262aea2af1` replaces `executorIdToHandler` with two maps:

```text
executorId -> actorId
actorId    -> ActorHandle
```

The first map follows the lifetime of a Spark executor generation. The second is both the actor-slot registry and the strong-reference holder for the Ray actor. Removing a disconnected executor ID now deletes only the generation mapping. The stable actor handle remains until the actor slot itself is deliberately removed, so Ray can restart the actor and register a new Spark `executorId`.

### Reconcile Immediately after `KillExecutors`

Spark's total-executor request is a persistent desired-state contract, not a one-shot request to create a delta. `CoarseGrainedSchedulerBackend` explicitly assumes that the cluster manager will eventually fulfill an acknowledged total request when resources become available. Consequently, the Spark driver does not periodically resend the same target merely because an executor disappears; the resource-management side is responsible for retaining the target and reconciling its actual resources against it.

YARN demonstrates this contract directly. `YarnAllocator` stores the driver's total in `targetNumExecutorsPerResourceProfileId`. On every allocator heartbeat, it computes:

```text
missing = target - pending - running - starting
```

When a container exits, the running count decreases and the next heartbeat requests a replacement, without requiring the Spark driver to resend its unchanged target.

Before this commit, RayDP retained `desiredExecutors`, but reconciled only when it received `RequestExecutors`. Consider a target of 1000 and Spark calling `killAndReplaceExecutor(17)`. Spark sends `KillExecutors` with `adjustTargetNumExecutors = false`, so its desired target correctly stays at 1000. RayAppMaster removes actor slot 17 and acknowledges the kill, leaving 999 slots. No new `RequestExecutors(1000)` is required by Spark's contract, and RayAppMaster had neither a periodic allocator loop nor a reconciliation call on this state transition. The application could therefore remain at 999 indefinitely; repeated replacement kills could accumulate the deficit.

This commit invokes `reconcileExecutors()` immediately after processing `KillExecutors`:

- For a real scale-down, Spark first lowers the total request, so `desiredExecutors` already matches the reduced slot count and no replacement is created.
- For kill-and-replace or health-related removal, Spark keeps the total request unchanged, so the removed slot immediately appears as a deficit and RayDP creates a replacement.

`RequestExecutors` and `KillExecutors` are the two events that change RayAppMaster's target or actor slot count. Reconciling on both events gives RayDP the same desired-state behavior that Spark expects from resource managers such as YARN, without requiring a periodic target synchronization from the driver.

## Related Issue

Fixes #

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Test update
- [x] Refactoring
- [ ] Build / CI / dependency change
- [ ] Other

## How was this tested?

This fix has been tested in our production environment and works well with dynamic execution enabled and 1,000 executors. Before this fix, large-scale jobs would occasionally fail.

## Checklist

- [ ] I have added or updated tests if needed
- [ ] I have updated documentation if needed
- [ ] I have run relevant tests locally
- [ ] I have checked that this change is backward compatible
