### PR TITLE
ci: pin Google API protos for TensorFlow compatibility

### DIFF
--- a/.github/workflows/raydp.yml
+++ b/.github/workflows/raydp.yml
@@ -82,7 +82,9 @@ jobs:
           else
             pip install torch
           fi
-          pip install pyarrow "ray[train,default]==${{ matrix.ray-version }}" tqdm pytest tabulate grpcio-tools wget
+          # TensorFlow 2.15 installs protobuf 4.x, so keep Google API protos compatible.
+          pip install pyarrow "ray[train,default]==${{ matrix.ray-version }}" \
+            "googleapis-common-protos==1.75.0" tqdm pytest tabulate grpcio-tools wget
           pip install "xgboost_ray[default]<=0.1.13"
           pip install "xgboost<=2.0.3"
           pip install torchmetrics
@@ -98,6 +100,7 @@ jobs:
           pip install pyspark==${{ matrix.spark-version }}
           ./build.sh
           pip install "$(ls dist/raydp-*.whl)[tensorflow]"
+          python -c "from google.rpc import code_pb2"
       - name: Lint
         run: |
           pip install pylint==3.2.7

--- a/README.md
+++ b/README.md
@@ -90,9 +90,9 @@ Spark features such as dynamic resource allocation, spark-submit script, etc are
 
 ## Spark + AI Pipeline on Ray
 
-RayDP provides APIs for converting a Spark DataFrame to a Ray Dataset which can be consumed by XGBoost, Ray Train, Horovod on Ray, etc. RayDP also provides high level scikit-learn style Estimator APIs for distributed training with PyTorch or Tensorflow. To get started with end-to-end Spark + AI pipeline, the easiest way is to run the following tutorials on Google Collab. More examples are also available in the `examples` folder.
-* [Spark + Ray Train Tutorial on Google Collab](https://colab.research.google.com/github/ray-project/raydp/blob/master/tutorials/raytrain_example.ipynb)
-* [Spark + TorchEstimator Tutorial on Google Collab](https://colab.research.google.com/github/ray-project/raydp/blob/master/tutorials/pytorch_example.ipynb)
+RayDP provides APIs for converting a Spark DataFrame to a Ray Dataset which can be consumed by XGBoost, Ray Train, Horovod on Ray, etc. RayDP also provides high level scikit-learn style Estimator APIs for distributed training with PyTorch or Tensorflow. To get started with end-to-end Spark + AI pipeline, the easiest way is to run the following tutorials on Google Colab. More examples are also available in the `examples` folder.
+* [Spark + Ray Train Tutorial on Google Colab](https://colab.research.google.com/github/ray-project/raydp/blob/master/tutorials/raytrain_example.ipynb)
+* [Spark + TorchEstimator Tutorial on Google Colab](https://colab.research.google.com/github/ray-project/raydp/blob/master/tutorials/pytorch_example.ipynb)
 
 
 ***Spark DataFrame & Ray Dataset conversion***


### PR DESCRIPTION
## Summary

- Pin `googleapis-common-protos` to 1.75.0, which remains compatible with the protobuf 4.x runtime installed by TensorFlow 2.15.
- Add a fast `google.rpc.code_pb2` import check before lint and pytest.
- Fix three `Google Collab` misspellings in the README.

## Background

`googleapis-common-protos` 1.75.2 requires protobuf 6.33.5 or newer, while the RayDP TensorFlow extra installs TensorFlow 2.15.1 and protobuf 4.25.9. The generated Google RPC modules then fail to import `google.protobuf.runtime_version`, causing the Ray dashboard agent and raylet to exit.
