### PR TITLE
Support every Spark 4.x patch release and add Spark 4.2

### DIFF
--- a/.github/workflows/ray_nightly_test.yml
+++ b/.github/workflows/ray_nightly_test.yml
@@ -32,7 +32,7 @@ jobs:
       matrix:
         os: [ ubuntu-latest ]
         python-version: ["3.10", "3.11"]
-        spark-version: [4.0.0, 4.1.0]
+        spark-version: [4.0.0, 4.1.0, 4.2.0]
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/raydp.yml
+++ b/.github/workflows/raydp.yml
@@ -33,7 +33,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version: ["3.10", "3.11"]
-        spark-version: [4.0.0, 4.1.0]
+        spark-version: [4.0.0, 4.1.0, 4.2.0]
         ray-version: [2.37.0, 2.40.0, 2.50.0]
 
     runs-on: ${{ matrix.os }}

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -20,6 +20,7 @@
     <spark350.version>3.5.0</spark350.version>
     <spark400.version>4.0.0</spark400.version>
     <spark410.version>4.1.0</spark410.version>
+    <spark420.version>4.2.0</spark420.version>
     <snappy.version>1.1.10.4</snappy.version>
     <netty.version>4.1.94.Final</netty.version>
     <commons.text.version>1.10.0</commons.text.version>

--- a/core/raydp-main/src/test/scala/com/intel/raydp/shims/SparkShimDescriptorTest.scala
+++ b/core/raydp-main/src/test/scala/com/intel/raydp/shims/SparkShimDescriptorTest.scala
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.raydp.shims
+
+import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertTrue}
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests for Spark version parsing and minor-line shim matching.
+ *
+ * A shim covers a whole `major.minor` line, so a newly published patch must resolve without any
+ * code change. These tests pin that, and pin the boundaries a naive prefix match would get wrong.
+ */
+class SparkShimDescriptorTest {
+
+  private class TestProvider(major: Int, minor: Int)
+    extends SparkMinorLineShimProvider(major, minor) {
+    override def createShim: SparkShims = throw new UnsupportedOperationException("unused")
+  }
+
+  @Test
+  def parsesAReleaseVersion(): Unit = {
+    assertEquals(Some(SparkShimDescriptor(4, 2, 0)), SparkShimDescriptor.parse("4.2.0"))
+    assertEquals(Some(SparkShimDescriptor(4, 1, 13)), SparkShimDescriptor.parse("4.1.13"))
+  }
+
+  @Test
+  def ignoresAQualifierSuffix(): Unit = {
+    // Spark reports versions such as 4.2.0-preview1 and 4.3.0-SNAPSHOT.
+    assertEquals(Some(SparkShimDescriptor(4, 2, 0)), SparkShimDescriptor.parse("4.2.0-preview1"))
+    assertEquals(Some(SparkShimDescriptor(4, 3, 0)), SparkShimDescriptor.parse("4.3.0-SNAPSHOT"))
+  }
+
+  @Test
+  def rejectsAVersionWithoutAPatchComponent(): Unit = {
+    assertEquals(None, SparkShimDescriptor.parse("4.2"))
+    assertEquals(None, SparkShimDescriptor.parse("not-a-version"))
+    assertEquals(None, SparkShimDescriptor.parse(""))
+  }
+
+  @Test
+  def matchesEveryPatchOfItsOwnLine(): Unit = {
+    val provider = new TestProvider(4, 1)
+    // 4.1.2 and 4.1.3 are released patches that an enumerated list would have missed.
+    Seq("4.1.0", "4.1.1", "4.1.2", "4.1.3", "4.1.99").foreach { version =>
+      assertTrue(provider.matches(version), s"expected $version to match the 4.1 line")
+    }
+  }
+
+  @Test
+  def doesNotMatchAnotherMinorLine(): Unit = {
+    val provider = new TestProvider(4, 1)
+    Seq("4.0.4", "4.2.0", "3.5.1").foreach { version =>
+      assertFalse(provider.matches(version), s"expected $version not to match the 4.1 line")
+    }
+  }
+
+  @Test
+  def doesNotConfuseMinorTenWithMinorOne(): Unit = {
+    // A prefix match on "4.1" would wrongly claim 4.10.x.
+    assertFalse(new TestProvider(4, 1).matches("4.10.0"))
+    assertTrue(new TestProvider(4, 10).matches("4.10.0"))
+  }
+
+  @Test
+  def doesNotMatchAnUnparseableVersion(): Unit = {
+    assertFalse(new TestProvider(4, 1).matches("unknown"))
+  }
+}

--- a/core/shims/common/src/main/scala/com/intel/raydp/shims/SparkShimProvider.scala
+++ b/core/shims/common/src/main/scala/com/intel/raydp/shims/SparkShimProvider.scala
@@ -24,3 +24,16 @@ trait SparkShimProvider {
   def matches(version:String): Boolean
   def createShim: SparkShims
 }
+
+/**
+ * Provider that claims every patch release of one Spark `major.minor` line.
+ *
+ * Spark keeps patch releases source and binary compatible within a minor line, so a single shim
+ * covers the whole line and a newly published patch needs no change here. Enumerating patches
+ * instead means a new patch fails shim resolution at runtime until someone widens the list.
+ */
+abstract class SparkMinorLineShimProvider(major: Int, minor: Int) extends SparkShimProvider {
+  override def matches(version: String): Boolean = {
+    SparkShimDescriptor.parse(version).exists(d => d.major == major && d.minor == minor)
+  }
+}

--- a/core/shims/common/src/main/scala/com/intel/raydp/shims/SparkShims.scala
+++ b/core/shims/common/src/main/scala/com/intel/raydp/shims/SparkShims.scala
@@ -31,6 +31,20 @@ case class SparkShimDescriptor(major: Int, minor: Int, patch: Int) extends ShimD
   override def toString(): String = s"$major.$minor.$patch"
 }
 
+object SparkShimDescriptor {
+  private val VersionPattern = """(\d+)\.(\d+)\.(\d+).*""".r
+
+  /**
+   * Parses a Spark version into a descriptor, ignoring any qualifier such as `-SNAPSHOT` or
+   * `-preview1`. Returns None when the version has no `major.minor.patch` prefix.
+   */
+  def parse(version: String): Option[SparkShimDescriptor] = version match {
+    case VersionPattern(major, minor, patch) =>
+      Some(SparkShimDescriptor(major.toInt, minor.toInt, patch.toInt))
+    case _ => None
+  }
+}
+
 trait SparkShims {
   def getShimDescriptor: ShimDescriptor
 

--- a/core/shims/pom.xml
+++ b/core/shims/pom.xml
@@ -23,6 +23,7 @@
     <module>spark350</module>
     <module>spark400</module>
     <module>spark410</module>
+    <module>spark420</module>
   </modules>
  
   <properties>

--- a/core/shims/spark410/src/main/scala/com/intel/raydp/shims/SparkShimProvider.scala
+++ b/core/shims/spark410/src/main/scala/com/intel/raydp/shims/SparkShimProvider.scala
@@ -20,18 +20,12 @@ package com.intel.raydp.shims.spark410
 import com.intel.raydp.shims.{SparkShims, SparkShimDescriptor}
 
 object SparkShimProvider {
-  private val SUPPORTED_PATCHES = 0 to 1
-  val DESCRIPTORS = SUPPORTED_PATCHES.map(p => SparkShimDescriptor(4, 1, p))
-  val DESCRIPTOR_STRINGS = DESCRIPTORS.map(_.toString)
-  val DESCRIPTOR = DESCRIPTORS.head
+  val DESCRIPTOR = SparkShimDescriptor(4, 1, 0)
 }
 
-class SparkShimProvider extends com.intel.raydp.shims.SparkShimProvider {
+class SparkShimProvider
+  extends com.intel.raydp.shims.SparkMinorLineShimProvider(4, 1) {
   def createShim: SparkShims = {
     new Spark410Shims()
-  }
-
-  def matches(version: String): Boolean = {
-    SparkShimProvider.DESCRIPTOR_STRINGS.contains(version)
   }
 }

--- a/core/shims/spark420/pom.xml
+++ b/core/shims/spark420/pom.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.intel</groupId>
+    <artifactId>raydp-shims</artifactId>
+    <version>1.7.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>raydp-shims-spark420</artifactId>
+  <name>RayDP Shims for Spark 4.2</name>
+  <packaging>jar</packaging>
+
+  <properties>
+    <scala.version>2.13.12</scala.version>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.scalastyle</groupId>
+        <artifactId>scalastyle-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>net.alchim31.maven</groupId>
+        <artifactId>scala-maven-plugin</artifactId>
+        <version>3.2.2</version>
+        <executions>
+          <execution>
+            <id>scala-compile-first</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>scala-test-compile-first</id>
+            <phase>process-test-resources</phase>
+            <goals>
+              <goal>testCompile</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+      </resource>
+    </resources>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.intel</groupId>
+      <artifactId>raydp-shims-common</artifactId>
+      <version>${project.version}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-sql_${scala.binary.version}</artifactId>
+      <version>${spark420.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-core_${scala.binary.version}</artifactId>
+      <version>${spark420.version}</version>
+      <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.xerial.snappy</groupId>
+          <artifactId>snappy-java</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-handler</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.xerial.snappy</groupId>
+      <artifactId>snappy-java</artifactId>
+      <version>${snappy.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-handler</artifactId>
+      <version>${netty.version}</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/core/shims/spark420/src/main/resources/META-INF/services/com.intel.raydp.shims.SparkShimProvider
+++ b/core/shims/spark420/src/main/resources/META-INF/services/com.intel.raydp.shims.SparkShimProvider
@@ -1,0 +1,1 @@
+com.intel.raydp.shims.spark420.SparkShimProvider

--- a/core/shims/spark420/src/main/scala/com/intel/raydp/shims/SparkShimProvider.scala
+++ b/core/shims/spark420/src/main/scala/com/intel/raydp/shims/SparkShimProvider.scala
@@ -15,17 +15,17 @@
  * limitations under the License.
  */
 
-package com.intel.raydp.shims.spark400
+package com.intel.raydp.shims.spark420
 
 import com.intel.raydp.shims.{SparkShims, SparkShimDescriptor}
 
 object SparkShimProvider {
-  val DESCRIPTOR = SparkShimDescriptor(4, 0, 0)
+  val DESCRIPTOR = SparkShimDescriptor(4, 2, 0)
 }
 
 class SparkShimProvider
-  extends com.intel.raydp.shims.SparkMinorLineShimProvider(4, 0) {
+  extends com.intel.raydp.shims.SparkMinorLineShimProvider(4, 2) {
   def createShim: SparkShims = {
-    new Spark400Shims()
+    new Spark420Shims()
   }
 }

--- a/core/shims/spark420/src/main/scala/com/intel/raydp/shims/SparkShims.scala
+++ b/core/shims/spark420/src/main/scala/com/intel/raydp/shims/SparkShims.scala
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.raydp.shims.spark420
+
+import org.apache.arrow.vector.types.pojo.Schema
+import org.apache.spark.api.java.JavaRDD
+import org.apache.spark.executor.{RayDPExecutorBackendFactory, RayDPSpark420ExecutorBackendFactory}
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.spark420.SparkSqlUtils
+import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.apache.spark.{SparkEnv, TaskContext}
+import org.apache.spark.spark420.TaskContextUtils
+import com.intel.raydp.shims.{CommandLineUtilsBridge, ShimDescriptor, SparkShims}
+import org.apache.spark.deploy.spark420.SparkSubmitUtils
+import org.apache.spark.rdd.RDD
+
+class Spark420Shims extends SparkShims {
+  override def getShimDescriptor: ShimDescriptor = SparkShimProvider.DESCRIPTOR
+
+  override def toDataFrame(
+      rdd: JavaRDD[Array[Byte]],
+      schema: String,
+      session: SparkSession): DataFrame = {
+    SparkSqlUtils.toDataFrame(rdd, schema, session)
+  }
+
+  override def getExecutorBackendFactory(): RayDPExecutorBackendFactory = {
+    new RayDPSpark420ExecutorBackendFactory()
+  }
+
+  override def getDummyTaskContext(partitionId: Int, env: SparkEnv): TaskContext = {
+    TaskContextUtils.getDummyTaskContext(partitionId, env)
+  }
+
+  override def toArrowSchema(
+      schema: StructType,
+      timeZoneId: String,
+      sparkSession: SparkSession): Schema = {
+    SparkSqlUtils.toArrowSchema(schema, timeZoneId, sparkSession)
+  }
+
+  override def toArrowBatchRDD(dataFrame: DataFrame): RDD[Array[Byte]] = {
+    SparkSqlUtils.toArrowRDD(dataFrame, dataFrame.sparkSession)
+  }
+
+  override def getCommandLineUtilsBridge: CommandLineUtilsBridge = {
+    SparkSubmitUtils
+  }
+}

--- a/core/shims/spark420/src/main/scala/org/apache/spark/TaskContextUtils.scala
+++ b/core/shims/spark420/src/main/scala/org/apache/spark/TaskContextUtils.scala
@@ -15,17 +15,16 @@
  * limitations under the License.
  */
 
-package com.intel.raydp.shims.spark400
+package org.apache.spark.spark420
 
-import com.intel.raydp.shims.{SparkShims, SparkShimDescriptor}
+import java.util.Properties
 
-object SparkShimProvider {
-  val DESCRIPTOR = SparkShimDescriptor(4, 0, 0)
-}
+import org.apache.spark.{SparkEnv, TaskContext, TaskContextImpl}
+import org.apache.spark.memory.TaskMemoryManager
 
-class SparkShimProvider
-  extends com.intel.raydp.shims.SparkMinorLineShimProvider(4, 0) {
-  def createShim: SparkShims = {
-    new Spark400Shims()
+object TaskContextUtils {
+  def getDummyTaskContext(partitionId: Int, env: SparkEnv): TaskContext = {
+    new TaskContextImpl(0, 0, partitionId, -1024, 0, 0,
+        new TaskMemoryManager(env.memoryManager, 0), new Properties(), env.metricsSystem)
   }
 }

--- a/core/shims/spark420/src/main/scala/org/apache/spark/deploy/spark420/SparkSubmitUtils.scala
+++ b/core/shims/spark420/src/main/scala/org/apache/spark/deploy/spark420/SparkSubmitUtils.scala
@@ -15,17 +15,19 @@
  * limitations under the License.
  */
 
-package com.intel.raydp.shims.spark400
+package org.apache.spark.deploy.spark420
 
-import com.intel.raydp.shims.{SparkShims, SparkShimDescriptor}
+import org.apache.spark.deploy.SparkSubmitArguments
+import org.apache.spark.util.CommandLineUtils
+import com.intel.raydp.shims.CommandLineUtilsBridge
 
-object SparkShimProvider {
-  val DESCRIPTOR = SparkShimDescriptor(4, 0, 0)
-}
+object SparkSubmitUtils
+    extends CommandLineUtils with CommandLineUtilsBridge {
+  override def main(args: Array[String]): Unit = {}
 
-class SparkShimProvider
-  extends com.intel.raydp.shims.SparkMinorLineShimProvider(4, 0) {
-  def createShim: SparkShims = {
-    new Spark400Shims()
+  override def callExit(code: Int): Unit = exitFn(code, None)
+
+  override def setSubmitMaster(args: Any, master: String): Unit = {
+    args.asInstanceOf[SparkSubmitArguments].maybeMaster = Some(master)
   }
 }

--- a/core/shims/spark420/src/main/scala/org/apache/spark/executor/RayCoarseGrainedExecutorBackend.scala
+++ b/core/shims/spark420/src/main/scala/org/apache/spark/executor/RayCoarseGrainedExecutorBackend.scala
@@ -15,17 +15,36 @@
  * limitations under the License.
  */
 
-package com.intel.raydp.shims.spark400
+package org.apache.spark.executor
 
-import com.intel.raydp.shims.{SparkShims, SparkShimDescriptor}
+import java.net.URL
 
-object SparkShimProvider {
-  val DESCRIPTOR = SparkShimDescriptor(4, 0, 0)
-}
+import org.apache.spark.SparkEnv
+import org.apache.spark.resource.ResourceProfile
+import org.apache.spark.rpc.RpcEnv
 
-class SparkShimProvider
-  extends com.intel.raydp.shims.SparkMinorLineShimProvider(4, 0) {
-  def createShim: SparkShims = {
-    new Spark400Shims()
-  }
+class RayCoarseGrainedExecutorBackend(
+    rpcEnv: RpcEnv,
+    driverUrl: String,
+    executorId: String,
+    bindAddress: String,
+    hostname: String,
+    cores: Int,
+    userClassPath: Seq[URL],
+    env: SparkEnv,
+    resourcesFileOpt: Option[String],
+    resourceProfile: ResourceProfile)
+  extends CoarseGrainedExecutorBackend(
+    rpcEnv,
+    driverUrl,
+    executorId,
+    bindAddress,
+    hostname,
+    cores,
+    env,
+    resourcesFileOpt,
+    resourceProfile) {
+
+  override def getUserClassPath: Seq[URL] = userClassPath
+
 }

--- a/core/shims/spark420/src/main/scala/org/apache/spark/executor/RayDPSpark420ExecutorBackendFactory.scala
+++ b/core/shims/spark420/src/main/scala/org/apache/spark/executor/RayDPSpark420ExecutorBackendFactory.scala
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.executor
+
+import org.apache.spark.SparkEnv
+import org.apache.spark.resource.ResourceProfile
+import org.apache.spark.rpc.RpcEnv
+
+import java.net.URL
+
+class RayDPSpark420ExecutorBackendFactory
+    extends RayDPExecutorBackendFactory {
+  override def createExecutorBackend(
+      rpcEnv: RpcEnv,
+      driverUrl: String,
+      executorId: String,
+      bindAddress: String,
+      hostname: String,
+      cores: Int,
+      userClassPath: Seq[URL],
+      env: SparkEnv,
+      resourcesFileOpt: Option[String],
+      resourceProfile: ResourceProfile): CoarseGrainedExecutorBackend = {
+    new RayCoarseGrainedExecutorBackend(
+      rpcEnv,
+      driverUrl,
+      executorId,
+      bindAddress,
+      hostname,
+      cores,
+      userClassPath,
+      env,
+      resourcesFileOpt,
+      resourceProfile)
+  }
+}

--- a/core/shims/spark420/src/main/scala/org/apache/spark/sql/SparkSqlUtils.scala
+++ b/core/shims/spark420/src/main/scala/org/apache/spark/sql/SparkSqlUtils.scala
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.spark420
+
+import org.apache.arrow.vector.types.pojo.Schema
+import org.apache.spark.TaskContext
+import org.apache.spark.api.java.JavaRDD
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.classic.ClassicConversions.castToImpl
+import org.apache.spark.sql.{DataFrame, Row, SparkSession}
+import org.apache.spark.sql.execution.arrow.ArrowConverters
+import org.apache.spark.sql.types._
+import org.apache.spark.sql.util.ArrowUtils
+
+object SparkSqlUtils {
+  def toDataFrame(
+      arrowBatchRDD: JavaRDD[Array[Byte]],
+      schemaString: String,
+      session: SparkSession): DataFrame = {
+    val schema = DataType.fromJson(schemaString).asInstanceOf[StructType]
+    val timeZoneId = session.sessionState.conf.sessionLocalTimeZone
+    val largeVarTypes = session.sessionState.conf.arrowUseLargeVarTypes
+    val internalRowRdd = arrowBatchRDD.rdd.mapPartitions { iter =>
+      val context = TaskContext.get()
+      ArrowConverters.fromBatchIterator(
+        arrowBatchIter = iter,
+        schema = schema,
+        timeZoneId = timeZoneId,
+        errorOnDuplicatedFieldNames = false,
+        largeVarTypes = largeVarTypes,
+        context = context)
+    }
+    session.internalCreateDataFrame(internalRowRdd.setName("arrow"), schema)
+  }
+
+  def toArrowRDD(dataFrame: DataFrame, sparkSession: SparkSession): RDD[Array[Byte]] = {
+    dataFrame.toArrowBatchRdd
+  }
+
+  def toArrowSchema(schema : StructType, timeZoneId : String, sparkSession: SparkSession) : Schema = {
+    val errorOnDuplicatedFieldNames =
+      sparkSession.sessionState.conf.pandasStructHandlingMode == "legacy"
+    val largeVarTypes =
+      sparkSession.sessionState.conf.arrowUseLargeVarTypes
+
+    ArrowUtils.toArrowSchema(
+      schema = schema,
+      timeZoneId = timeZoneId,
+      errorOnDuplicatedFieldNames = errorOnDuplicatedFieldNames,
+      largeVarTypes = largeVarTypes
+    )
+  }
+}

--- a/python/setup.py
+++ b/python/setup.py
@@ -101,7 +101,7 @@ try:
         "psutil",
         "pyarrow >= 4.0.1",
         "ray >= 2.37.0",
-        "pyspark >= 4.0.0, <= 4.1.1",
+        "pyspark >= 4.0.0, < 4.3.0",
         "protobuf > 3.19.5"
     ]
 


### PR DESCRIPTION
## What does this PR do?

Two related changes to Spark version support:

1. **Shims now cover a whole `major.minor` line**, so every patch release of a supported minor works without a code change.
2. **Adds a shim for Spark 4.2** and registers `4.2.0` in both test matrices.

## Why is this change needed?

Each shim provider enumerated the patch releases it claimed, and `matches()` compared the running Spark version against that list by exact string:

```scala
private val SUPPORTED_PATCHES = 0 to 1
val DESCRIPTOR_STRINGS = SUPPORTED_PATCHES.map(p => SparkShimDescriptor(4, 1, p).toString)
def matches(version: String): Boolean = DESCRIPTOR_STRINGS.contains(version)
```

Spark keeps patch releases source and binary compatible within a minor line, but any patch outside the hard-coded range fails shim resolution at runtime with `No Spark Shim Provider found for <version>`. Several released versions were already unreachable:

| Line | Released patches | Previously claimed |
| ---- | ---------------- | ------------------ |
| 4.0.x | 4.0.0 – 4.0.4 | 4.0.0 – 4.0.2 |
| 4.1.x | 4.1.0 – 4.1.3 | 4.1.0 – 4.1.1 |

So `pyspark==4.1.3` failed even though nothing in the shim was incompatible, and every future patch would need a follow-up PR.

`SparkMinorLineShimProvider` now parses the running version and claims any patch of the line it was constructed for. Two details are deliberate:

- Parsing tolerates a qualifier, so `4.2.0-preview1` and `4.3.0-SNAPSHOT` resolve to their base version.
- Matching compares parsed components rather than string prefixes, so the `4.1` line does not claim `4.10.x`.

The `pyspark` requirement becomes a bounded range over the supported lines (`>= 4.0.0, < 4.3.0`) instead of a specific patch ceiling, so pip can install any patch we cover and nothing past it.

The 3.x shims are left alone — they enumerate patch lists (and `spark322` deliberately claims some 3.1.x versions), so converting them is a separate decision with its own compatibility question.

## Related Issue

Fixes #

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring
- [ ] Build / CI / dependency change
- [ ] Other

## How was this tested?

**New unit tests** — `core/raydp-main/src/test/scala/com/intel/raydp/shims/SparkShimDescriptorTest.scala`, 7 cases covering version parsing, qualifier suffixes, unparseable input, every patch of a line matching, other minor lines not matching, and the `4.1` vs `4.10` boundary.

```
Tests run: 7, Failures: 0, Errors: 0, Skipped: 0 -- SparkShimDescriptorTest
Tests run: 7, Failures: 0, Errors: 0, Skipped: 0 -- ApplicationInfoTest
Tests run: 14, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

**Full build of all 12 modules**, including the new shim compiling against Spark 4.2.0:

```
RayDP Shims for Spark 4.0.0 ........................ SUCCESS
RayDP Shims for Spark 4.1.0 ........................ SUCCESS
RayDP Shims for Spark 4.2 .......................... SUCCESS
BUILD SUCCESS
```

The Spark 4.2 shim needed no source changes beyond the package and class renames, so the shimmed APIs are unchanged between 4.1 and 4.2.

Also verified that the new shim jar is named `raydp-shims-spark420-1.7.0-SNAPSHOT.jar`, which matches the `raydp-*.jar` glob `python/setup.py` uses to bundle jars into the wheel, and that no new lines exceed the 100-column scalastyle limit.

**Not run locally:** the pytest suite, which needs a live Ray cluster, and any run against a real 4.2.0 cluster. CI covers those across the matrix.

## Checklist

- [x] I have added or updated tests if needed
- [ ] I have updated documentation if needed
- [x] I have run relevant tests locally
- [x] I have checked that this change is backward compatible
